### PR TITLE
fix(bot): convert BigInt chatId to string before logging

### DIFF
--- a/backend/src/bot/handlers/invitation.handler.ts
+++ b/backend/src/bot/handlers/invitation.handler.ts
@@ -60,7 +60,7 @@ export function registerInvitationHandler(): void {
       }
 
       logger.info('Processing invitation via /start', {
-        chatId,
+        chatId: String(chatId),
         tokenLength: payload.length,
         service: 'invitation-handler',
       });
@@ -97,7 +97,7 @@ export function registerInvitationHandler(): void {
       }
 
       logger.info('Processing invitation via /connect', {
-        chatId,
+        chatId: String(chatId),
         tokenLength: token.length,
         service: 'invitation-handler',
       });
@@ -135,8 +135,8 @@ export function registerInvitationHandler(): void {
       await ctx.reply(helpMessage, { parse_mode: 'Markdown' });
 
       logger.info('Help command processed', {
-        chatId: ctx.chat?.id,
-        userId: ctx.from?.id,
+        chatId: ctx.chat?.id ? String(ctx.chat.id) : undefined,
+        userId: ctx.from?.id ? String(ctx.from.id) : undefined,
         service: 'invitation-handler',
       });
     } catch (error) {
@@ -166,7 +166,7 @@ async function processInvitation(
   if (!isValidTokenFormat(token)) {
     logger.warn('Invalid token format attempted', {
       tokenLength: token.length,
-      chatId,
+      chatId: String(chatId),
       service: 'invitation-handler',
     });
     await ctx.reply('❌ Неверный формат кода приглашения.');
@@ -206,7 +206,7 @@ async function processInvitation(
       try {
         inviteLink = await ctx.telegram.exportChatInviteLink(Number(chatId));
         logger.info('Fetched invite link for chat', {
-          chatId,
+          chatId: String(chatId),
           hasInviteLink: !!inviteLink,
           service: 'invitation-handler',
         });
@@ -214,7 +214,7 @@ async function processInvitation(
         // Bot might not have permission to export invite links
         // This is not critical - we can still register the chat
         logger.warn('Failed to fetch invite link (bot might lack permissions)', {
-          chatId,
+          chatId: String(chatId),
           error: error instanceof Error ? error.message : String(error),
           service: 'invitation-handler',
         });
@@ -258,7 +258,7 @@ async function processInvitation(
     await ctx.reply('✅ Чат успешно подключен!\nТеперь мы на связи. История сообщений сохраняется.');
 
     logger.info('Invitation successfully processed', {
-      chatId,
+      chatId: String(chatId),
       tokenPrefix: token.substring(0, 8) + '...',
       service: 'invitation-handler'
     });
@@ -285,7 +285,7 @@ async function processInvitation(
     // Log unexpected errors
     logger.error('Unexpected error processing invitation', {
       error: errorMessage,
-      chatId,
+      chatId: String(chatId),
       service: 'invitation-handler',
     });
 


### PR DESCRIPTION
## Summary

Fixes #3 - BigInt serialization error in invitation handler logging

The invitation handler was passing Telegram `chatId` (BigInt) directly to Winston logger, which calls `JSON.stringify()` internally. Since JavaScript's `JSON.stringify()` doesn't support BigInt values, this caused:

```
Do not know how to serialize a BigInt
```

**This bug was blocking chat registration entirely** via `/connect` and `/start` commands, which explains why the production bot was not responding to messages - chats couldn't be registered in the first place.

## Changes

- Convert `chatId` to `String()` in all `logger.info/warn/error` calls
- Convert `userId` to `String()` where applicable

## Test Plan

- [x] Tested locally with real Telegram bot
- [x] `/connect <token>` now succeeds instead of showing "Произошла ошибка при подключении"
- [x] Chat is registered in database after successful connection
- [ ] Verify in production after deployment

## Root Cause Analysis

The error occurred in 8 places within `invitation.handler.ts` where BigInt values were logged:
- Lines 63, 100, 138-139, 169, 209, 217, 261, 288

All converted from `chatId` to `String(chatId)`.

Made with [Cursor](https://cursor.com)