### PR TITLE
docs(agents): document handling of git commit and Husky hook errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ bd sync               # Sync with git
 2. **Run quality gates** (if code changed) - Tests, linters, builds
 3. **Update issue status** - Close finished work, update in-progress items
 4. **PUSH TO REMOTE** - This is MANDATORY:
+   - **Commit before pushing**: Stage with `git add`, then run `git commit -m "..."`. **Always check the command output and exit code.** If `git commit` fails, the output contains the reason (lint, format, or commit message). Fix those issues and run `git commit` again. Do not use `git commit --no-verify` unless the user explicitly requests it.
    ```bash
    git pull --rebase
    bd sync
@@ -38,3 +39,4 @@ bd sync               # Sync with git
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
+- If **commit** fails (e.g. pre-commit or commit-msg hook), read the terminal output, fix the reported issues (ESLint, Prettier, or commit message format), and retry `git commit`. Do not assume the commit succeeded without checking.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Run `/push patch` after EACH completed task:
 - Add artifacts: `→ Artifacts: [file1](path), [file2](path)`
 - Update TodoWrite to completed
 - Then `/push patch`
+- After the command that runs `git commit`, **verify it succeeded** (exit code 0). If it failed, the output contains ESLint/Prettier/commitlint errors—fix those and commit again.
 
 Commit messages MUST follow [docs/COMMIT_CONVENTIONS.md](docs/COMMIT_CONVENTIONS.md) (Conventional Commits + Release Please). Use the **format-commit-message** skill for every commit (including when passing `-m "..."` to `/push`).
 
@@ -160,14 +161,20 @@ All issues use `buh-` prefix: `buh-abc123`
 
 ```bash
 git status              # 1. What changed?
-git add <files>         # 2. Stage code
+git add <files>         # 2. Stage the right files (match lint-staged patterns if unsure)
 bd sync                 # 3. Sync beads
 git commit -m "... (buh-xxx)"  # 4. Commit with issue ID
+# If step 4 fails: read the command output. Pre-commit runs ESLint+Prettier on staged files;
+# commit-msg runs commitlint. Fix the reported issues (code or message), then re-run from step 2.
 bd sync                 # 5. Sync any new changes
 git push                # 6. Push to remote
 ```
 
 **Work is NOT done until pushed!**
+
+**Commit failures:** Always check the **exit code and full output** of `git commit`. On failure, the output shows either lint/format errors (fix code and re-stage) or commitlint errors (fix the message and retry). Retry until `git commit` succeeds, then continue with `bd sync` and `git push`.
+
+**Git hooks (Husky):** Pre-commit runs `lint-staged` (ESLint + Prettier on staged files). Commit-msg runs `commitlint`. Both print to the **same terminal** as `git commit`. There are no separate log files. To "see" hook errors, always capture and check the **output and exit code** of `git commit`.
 
 ### When to Use What
 
@@ -202,6 +209,7 @@ git push                # 6. Push to remote
 
 - Type-check must pass before commit
 - Build must pass before commit
+- **Pre-commit hooks (Husky)** run on `git commit`: lint-staged (ESLint + Prettier on staged files) and commitlint (message format). If commit fails, the **terminal output** of the commit command contains the errors; fix and retry. Do not use `--no-verify` unless explicitly asked.
 - No hardcoded credentials
 
 **Agent Selection**:

--- a/docs/adr/001-precommit-hooks-with-husky.md
+++ b/docs/adr/001-precommit-hooks-with-husky.md
@@ -151,6 +151,7 @@ Use [Lefthook](https://github.com/evilmartians/lefthook) - a fast Git hooks mana
 - CI still runs lint checks as a safety net for `--no-verify` bypasses
 - Documentation updated to explain the workflow
 - Hooks use `--fix` to auto-resolve most issues
+- **For agents:** When running `git commit`, always check the command's exit code and output. Hook failures (lint-staged, commitlint) are reported there. See AGENTS.md and CLAUDE.md (Session Close Protocol, Commit Strategy) for required behavior.
 
 ## References
 


### PR DESCRIPTION
Instruct agents to check exit code and output of `git commit`; on pre-commit or commit-msg failure, fix reported issues and retry.

**Changes:**
- **AGENTS.md**: Commit-before-push note; always check command output/exit code; new critical rule for commit failures.
- **CLAUDE.md**: Session Close Protocol (inline comment + commit-failure paragraph); Git hooks note; Commit Strategy verification bullet; Code Standards Husky bullet.
- **ADR-001**: Mitigation bullet for agents (point to AGENTS.md / CLAUDE.md).

Made with [Cursor](https://cursor.com)