### PR TITLE
feat(ci): switch to feature branch + pr workflow

### DIFF
--- a/.claude/commands/speckit.implement.md
+++ b/.claude/commands/speckit.implement.md
@@ -167,7 +167,7 @@ You **MUST** consider the user input before proceeding (if not empty).
       - Reject? → Re-delegate with corrections and error messages, go to step 4
    7. UPDATE TODO: Mark task `completed` in TodoWrite
    8. UPDATE tasks.md: Mark task `[X]`, add artifacts: `→ Artifacts: [file1](path), [file2](path)`
-   9. COMMIT: Run `/push patch`
+   9. COMMIT: Run `/push` (or `/push -m "feat(scope): description"`)
    10. NEXT TASK: Move to next incomplete task, go to step 1
 
 9. Implementation execution rules:
@@ -180,7 +180,7 @@ You **MUST** consider the user input before proceeding (if not empty).
 10. Progress tracking and error handling:
 
 - Report progress after each completed task
-- **Commit after each task**: Run `/push patch` before moving to next
+- **Commit after each task**: Run `/push` before moving to next
 - Halt execution if any non-parallel task fails
 - For parallel tasks [P], continue with successful tasks, report failed ones
 - Provide clear error messages with context for debugging

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   NODE_VERSION: '20'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,17 +54,17 @@ Everything else: delegate.
 
 **5. COMMIT STRATEGY**
 
-Run `/push patch` after EACH completed task:
+Run `/push` after EACH completed task (commits to feature branch, creates/updates PR to main):
 
 - Mark task [X] in tasks.md
 - Add artifacts: `→ Artifacts: [file1](path), [file2](path)`
 - Update TodoWrite to completed
-- Then `/push patch`
+- Then `/push` (or `/push -m "feat(scope): description"`)
 - After the command that runs `git commit`, **verify it succeeded** (exit code 0). If it failed, the output contains ESLint/Prettier/commitlint errors—fix those and commit again.
 
 Commit messages MUST follow [docs/COMMIT_CONVENTIONS.md](docs/COMMIT_CONVENTIONS.md) (Conventional Commits + Release Please). Use the **format-commit-message** skill for every commit (including when passing `-m "..."` to `/push`).
 
-**Release automation:** Releases and CHANGELOG are produced by **Release Please** when changes are merged to `main`. Commits must follow the conventions so Release Please can parse them. **`/push patch`** is for committing and pushing feature work (and optionally running the legacy release script); **version bumps and CHANGELOG updates** for the mainline release happen via the Release Please-created PR, not by running `/push` on `main` to create a release commit.
+**Release automation:** Releases and CHANGELOG are produced by **Release Please** when PRs are merged to `main`. Commits must follow the conventions so Release Please can parse them. `/push` commits and pushes to a feature branch, then creates a PR. **Version bumps and CHANGELOG updates** happen via the Release Please-created PR after merge, not manually.
 
 **6. EXECUTION PATTERN**
 
@@ -77,7 +77,7 @@ FOR EACH TASK:
 5. Accept/reject loop (re-delegate if needed)
 6. Update TodoWrite to completed
 7. Mark task [X] in tasks.md + add artifacts
-8. Run /push patch
+8. Run /push
 9. Move to next task
 ```
 
@@ -169,10 +169,11 @@ git commit -m "... (buh-xxx)"  # 4. Commit with issue ID
 # If step 4 fails: read the command output. Pre-commit runs ESLint+Prettier on staged files;
 # commit-msg runs commitlint. Fix the reported issues (code or message), then re-run from step 2.
 bd sync                 # 5. Sync any new changes
-git push                # 6. Push to remote
+git push -u origin HEAD # 6. Push feature branch to remote
+gh pr create || gh pr view  # 7. Create PR to main (or view existing)
 ```
 
-**Work is NOT done until pushed!**
+**Work is NOT done until PR is created!**
 
 **Commit failures:** Always check the **exit code and full output** of `git commit`. On failure, the output shows either lint/format errors (fix code and re-stage) or commitlint errors (fix the message and retry). Retry until `git commit` succeeds, then continue with `bd sync` and `git push`.
 
@@ -206,6 +207,15 @@ git push                # 6. Push to remote
 - Skills: `.claude/skills/{skill-name}/SKILL.md`
 - Temporary: `.tmp/current/` (git ignored)
 - Reports: `docs/reports/{domain}/{YYYY-MM}/`
+
+**Git Workflow**:
+
+- Always work on feature branches, never push directly to main
+- Branch naming: `feat/<issue-id>`, `fix/<issue-id>`, `chore/<description>`
+- Use `/push` to commit, push feature branch, and create PR
+- PRs merge to main via GitHub (squash merge preferred)
+- Release Please creates release PR automatically after merge to main
+- Direct push to main is blocked by branch protection
 
 **Code Standards**:
 


### PR DESCRIPTION
## Summary

- Fix CI concurrency: `cancel-in-progress` only for PRs, not main
- Rewrite `/push` command: commit → push branch → create PR
- Update CLAUDE.md: session close protocol, git workflow rules
- Update speckit.implement.md: `/push patch` → `/push`

## Beads

buh-h7d

## Next step (after merge)

Apply branch protection via `gh api` to block direct pushes to main.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>