### PR TITLE
feat(bot): add diagnose command and privacy mode warnings

### DIFF
--- a/backend/src/bot/webhook.ts
+++ b/backend/src/bot/webhook.ts
@@ -85,8 +85,33 @@ export async function setupWebhook(app: Application, webhookPath: string): Promi
       { command: 'menu', description: 'Открыть меню' },
       { command: 'help', description: 'Помощь' },
       { command: 'connect', description: 'Подключить чат (код)' },
+      { command: 'diagnose', description: 'Диагностика получения сообщений' },
     ]);
     logger.debug('Bot commands set successfully', { service: 'webhook' });
+
+    // Check Privacy Mode on startup and log warning if enabled
+    try {
+      const botInfo = await bot.telegram.getMe();
+      if (!botInfo.can_read_all_group_messages) {
+        logger.warn(
+          'Privacy Mode is ON: bot cannot read messages in supergroups where it is not admin. ' +
+            'Disable via BotFather or ensure bot is admin in all monitored supergroups.',
+          { service: 'webhook' }
+        );
+      } else {
+        logger.info('Privacy Mode is OFF: bot can read all group messages', {
+          service: 'webhook',
+        });
+      }
+    } catch (privacyCheckError) {
+      logger.warn('Failed to check Privacy Mode on startup', {
+        error:
+          privacyCheckError instanceof Error
+            ? privacyCheckError.message
+            : String(privacyCheckError),
+        service: 'webhook',
+      });
+    }
 
     logger.info('Telegram webhook configured successfully', {
       webhookUrl: fullWebhookUrl,


### PR DESCRIPTION
## Summary

- Add `/diagnose` command for runtime chat diagnostics (checks Privacy Mode, bot status, DB registration, message count, gives verdict)
- Add Privacy Mode warning after `/connect` if bot is not admin
- Add proactive warning when bot is added to supergroup without admin rights
- Log Privacy Mode status on bot startup
- Fix `Number(chatId)` precision issue in `exportChatInviteLink`

## Root cause analysis (buh-4el)

Messages from supergroup -1003476024757 not appearing on website.
SQL diagnostics confirmed **Hypothesis A**: `message_count = 0`, chat is registered correctly but bot doesn't receive regular messages because Privacy Mode is ON and bot is not admin in the supergroup.

## Changes

| File | Change |
|------|--------|
| `system.handler.ts` | New `/diagnose` command |
| `invitation.handler.ts` | Admin check after `/connect`, `/diagnose` in help, `Number(chatId)` fix |
| `chat-event.handler.ts` | Proactive Privacy Mode warning on bot add |
| `webhook.ts` | Register `/diagnose` command, startup Privacy Mode check |

## Test plan

- [ ] Deploy and run `/diagnose` in chat -1003476024757 to confirm diagnosis
- [ ] Promote bot to admin in the chat, verify messages start appearing
- [ ] Test `/connect` on a new group where bot is NOT admin, verify warning
- [ ] Test `/diagnose` in a working chat to verify healthy output
- [ ] Backend type-check passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)