### PR TITLE
feat(bot): add suggested admin rights and group invite links

### DIFF
--- a/backend/src/api/trpc/routers/chats.ts
+++ b/backend/src/api/trpc/routers/chats.ts
@@ -20,7 +20,7 @@ import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { Prisma } from '@prisma/client';
 import logger from '../../../utils/logger.js';
-import { isProduction } from '../../../config/env.js';
+import env, { isProduction } from '../../../config/env.js';
 import { randomBytes } from 'crypto';
 import { safeNumberFromBigInt } from '../../../utils/bigint.js';
 
@@ -814,9 +814,8 @@ export const chatsRouter = router({
         },
       });
 
-      // Get bot username from environment (required for deep links)
-      // Enforce strict check as per production requirements
-      const botUsername = process.env['BOT_USERNAME'];
+      // Get bot username from validated env (required for deep links)
+      const botUsername = env.BOT_USERNAME;
       if (!botUsername) {
         throw new TRPCError({
           code: 'INTERNAL_SERVER_ERROR',

--- a/backend/src/bot/utils/bot-info.ts
+++ b/backend/src/bot/utils/bot-info.ts
@@ -1,0 +1,84 @@
+/**
+ * Cached Bot Info & Shared Messages
+ *
+ * Provides cached getMe() result and reusable bot message templates.
+ * Avoids repeated Telegram API calls for static bot properties.
+ *
+ * @module bot/utils/bot-info
+ */
+
+import { bot } from '../bot.js';
+import logger from '../../utils/logger.js';
+
+/** Cached result of getMe() — bot properties are static per token */
+let cachedBotInfo: Awaited<ReturnType<typeof bot.telegram.getMe>> | null = null;
+
+/**
+ * Get bot info with caching.
+ * First call hits Telegram API; subsequent calls return cached result.
+ */
+export async function getBotInfo(): Promise<Awaited<ReturnType<typeof bot.telegram.getMe>>> {
+  if (!cachedBotInfo) {
+    cachedBotInfo = await bot.telegram.getMe();
+  }
+  return cachedBotInfo;
+}
+
+/**
+ * Clear cached bot info (useful for tests or after BotFather changes).
+ */
+export function clearBotInfoCache(): void {
+  cachedBotInfo = null;
+}
+
+/**
+ * Check if Privacy Mode is enabled (bot cannot read all group messages).
+ * Uses cached bot info.
+ */
+export async function isPrivacyModeOn(): Promise<boolean> {
+  const info = await getBotInfo();
+  return !info.can_read_all_group_messages;
+}
+
+/**
+ * Generate Privacy Mode warning message with step-by-step admin promotion guide.
+ * Handles undefined bot username gracefully.
+ */
+export function privacyModeWarning(botUsername: string | undefined): string {
+  const usernameRef = botUsername ? `@${botUsername}` : 'бота';
+  return (
+    '⚠️ Для корректной работы боту нужны права администратора.\n\n' +
+    'Без прав админа бот не видит обычные сообщения в групповых чатах.\n\n' +
+    'Как исправить:\n' +
+    '1. Откройте настройки группы\n' +
+    '2. Перейдите в «Администраторы»\n' +
+    `3. Назначьте ${usernameRef} администратором\n` +
+    '4. Достаточно минимальных прав (только «Управление чатом»)'
+  );
+}
+
+/**
+ * Initialize bot info cache. Call once on startup.
+ * Logs Privacy Mode status.
+ */
+export async function initBotInfo(): Promise<void> {
+  try {
+    const info = await getBotInfo();
+    if (!info.can_read_all_group_messages) {
+      logger.warn(
+        'Privacy Mode is ON: bot cannot read messages in groups where it is not admin. ' +
+          'Disable via BotFather or ensure bot is admin in all monitored groups.',
+        { service: 'bot-info' }
+      );
+    } else {
+      logger.info('Privacy Mode is OFF: bot can read all group messages', {
+        service: 'bot-info',
+      });
+    }
+  } catch (error) {
+    logger.warn('Failed to initialize bot info cache', {
+      error: error instanceof Error ? error.message : String(error),
+      service: 'bot-info',
+    });
+  }
+}

--- a/backend/src/bot/webhook.ts
+++ b/backend/src/bot/webhook.ts
@@ -16,6 +16,58 @@ import type { Application } from 'express';
 import { bot } from './bot.js';
 import logger from '../utils/logger.js';
 import env from '../config/env.js';
+import { initBotInfo } from './utils/bot-info.js';
+
+/** CR-14: Shared bot command list for both webhook and polling modes */
+const BOT_COMMANDS = [
+  { command: 'start', description: 'Начать работу с ботом' },
+  { command: 'menu', description: 'Открыть меню' },
+  { command: 'help', description: 'Помощь' },
+  { command: 'connect', description: 'Подключить чат (код)' },
+  { command: 'diagnose', description: 'Диагностика получения сообщений' },
+];
+
+/**
+ * Configure bot defaults shared between webhook and polling modes.
+ * Sets bot commands, default admin rights, and initializes bot info cache.
+ */
+async function configureBotDefaults(): Promise<void> {
+  // Set bot commands for menu button
+  await bot.telegram.setMyCommands(BOT_COMMANDS);
+  logger.debug('Bot commands set successfully', { service: 'webhook' });
+
+  // CR-2: Set suggested admin rights for groups. These are shown to users when
+  // promoting the bot through Telegram's admin UI (independent of &admin= links).
+  try {
+    await bot.telegram.setMyDefaultAdministratorRights({
+      rights: {
+        is_anonymous: false,
+        can_manage_chat: true,
+        can_delete_messages: false,
+        can_manage_video_chats: false,
+        can_restrict_members: false,
+        can_promote_members: false,
+        can_change_info: false,
+        can_invite_users: false,
+        can_pin_messages: false,
+        can_manage_topics: false,
+      },
+      forChannels: false,
+    });
+    logger.info('Default administrator rights set (manage_chat only)', {
+      service: 'webhook',
+    });
+  } catch (adminRightsError) {
+    logger.warn('Failed to set default administrator rights', {
+      error:
+        adminRightsError instanceof Error ? adminRightsError.message : String(adminRightsError),
+      service: 'webhook',
+    });
+  }
+
+  // Initialize bot info cache and log Privacy Mode status
+  await initBotInfo();
+}
 
 /**
  * Setup webhook for Telegram bot
@@ -79,68 +131,7 @@ export async function setupWebhook(app: Application, webhookPath: string): Promi
     // but we need explicit path matching for Express routing
     app.post(webhookPath, webhookMiddleware);
 
-    // Set bot commands for menu button
-    await bot.telegram.setMyCommands([
-      { command: 'start', description: 'Начать работу с ботом' },
-      { command: 'menu', description: 'Открыть меню' },
-      { command: 'help', description: 'Помощь' },
-      { command: 'connect', description: 'Подключить чат (код)' },
-      { command: 'diagnose', description: 'Диагностика получения сообщений' },
-    ]);
-    logger.debug('Bot commands set successfully', { service: 'webhook' });
-
-    // Set suggested admin rights for groups (Telegram will propose these
-    // when the bot is added as admin via t.me link with &admin= parameter)
-    try {
-      await bot.telegram.setMyDefaultAdministratorRights({
-        rights: {
-          is_anonymous: false,
-          can_manage_chat: true,
-          can_delete_messages: false,
-          can_manage_video_chats: false,
-          can_restrict_members: false,
-          can_promote_members: false,
-          can_change_info: false,
-          can_invite_users: false,
-          can_pin_messages: false,
-          can_manage_topics: false,
-        },
-        for_channels: false,
-      });
-      logger.info('Default administrator rights set (manage_chat only)', {
-        service: 'webhook',
-      });
-    } catch (adminRightsError) {
-      logger.warn('Failed to set default administrator rights', {
-        error:
-          adminRightsError instanceof Error ? adminRightsError.message : String(adminRightsError),
-        service: 'webhook',
-      });
-    }
-
-    // Check Privacy Mode on startup and log warning if enabled
-    try {
-      const botInfo = await bot.telegram.getMe();
-      if (!botInfo.can_read_all_group_messages) {
-        logger.warn(
-          'Privacy Mode is ON: bot cannot read messages in supergroups where it is not admin. ' +
-            'Disable via BotFather or ensure bot is admin in all monitored supergroups.',
-          { service: 'webhook' }
-        );
-      } else {
-        logger.info('Privacy Mode is OFF: bot can read all group messages', {
-          service: 'webhook',
-        });
-      }
-    } catch (privacyCheckError) {
-      logger.warn('Failed to check Privacy Mode on startup', {
-        error:
-          privacyCheckError instanceof Error
-            ? privacyCheckError.message
-            : String(privacyCheckError),
-        service: 'webhook',
-      });
-    }
+    await configureBotDefaults();
 
     logger.info('Telegram webhook configured successfully', {
       webhookUrl: fullWebhookUrl,
@@ -230,9 +221,8 @@ export async function launchPolling(): Promise<void> {
     // Remove any existing webhook before starting polling
     await removeWebhook();
 
-    // Set bot commands for menu button
-    await bot.telegram.setMyCommands([{ command: 'menu', description: 'Открыть меню' }]);
-    logger.debug('Bot commands set successfully', { service: 'webhook' });
+    // CR-8: Use same defaults as webhook mode
+    await configureBotDefaults();
 
     // Start polling
     await bot.launch();

--- a/frontend/src/components/chats/InvitationModal.tsx
+++ b/frontend/src/components/chats/InvitationModal.tsx
@@ -126,13 +126,16 @@ export function InvitationModal({ isOpen, onClose, onSuccess }: InvitationModalP
     });
   };
 
-  // Copy to clipboard
-  const copyToClipboard = async (text: string, type: 'link' | 'command') => {
+  // CR-11: Copy to clipboard with separate state for each copy target
+  const copyToClipboard = async (text: string, type: 'link' | 'groupLink' | 'command') => {
     try {
       await navigator.clipboard.writeText(text);
       if (type === 'link') {
         setCopiedLink(true);
         setTimeout(() => setCopiedLink(false), 2000);
+      } else if (type === 'groupLink') {
+        setCopiedGroupLink(true);
+        setTimeout(() => setCopiedGroupLink(false), 2000);
       } else {
         setCopiedCommand(true);
         setTimeout(() => setCopiedCommand(false), 2000);
@@ -284,7 +287,7 @@ export function InvitationModal({ isOpen, onClose, onSuccess }: InvitationModalP
               <div className="space-y-4">
                 {/* Description */}
                 <p className="text-sm text-[var(--buh-foreground-muted)]">
-                  Ссылка добавит бота в группу с правами на чтение сообщений
+                  Ссылка откроет диалог добавления бота в группу с предложением прав администратора
                 </p>
 
                 {/* Accountant Select */}
@@ -344,11 +347,7 @@ export function InvitationModal({ isOpen, onClose, onSuccess }: InvitationModalP
                         type="button"
                         variant="outline"
                         size="icon"
-                        onClick={() => {
-                          copyToClipboard(generatedGroupLink, 'link');
-                          setCopiedGroupLink(true);
-                          setTimeout(() => setCopiedGroupLink(false), 2000);
-                        }}
+                        onClick={() => copyToClipboard(generatedGroupLink, 'groupLink')}
                         className="shrink-0"
                       >
                         {copiedGroupLink ? (
@@ -359,8 +358,8 @@ export function InvitationModal({ isOpen, onClose, onSuccess }: InvitationModalP
                       </Button>
                     </div>
                     <p className="text-xs text-[var(--buh-foreground-subtle)] mt-2">
-                      Клиент перейдёт по ссылке, выберет группу, и бот будет добавлен с правами
-                      администратора для чтения сообщений.
+                      Клиент перейдёт по ссылке, выберет группу и подтвердит назначение бота
+                      администратором с минимальными правами.
                     </p>
                   </div>
                 )}


### PR DESCRIPTION
## Summary

- Set `setMyDefaultAdministratorRights` on startup with `manage_chat` — Telegram will suggest these rights when promoting bot to admin
- Generate `t.me/bot?startgroup=token&admin=manage_chat` links in `createInvitation` API
- Show group invite link as primary method in InvitationModal "Код" tab — one click adds bot with admin rights
- Improve admin warning messages with step-by-step Russian instructions including bot @username

## Changes

| File | Change |
|------|--------|
| `webhook.ts` | `setMyDefaultAdministratorRights` call on startup |
| `chats.ts` | New `groupLink` field in `createInvitation` response |
| `InvitationModal.tsx` | Show group link (primary) + connect code (fallback) |
| `invitation.handler.ts` | Improved warning with step-by-step admin guide |
| `chat-event.handler.ts` | Improved warning with step-by-step admin guide |

## Telegram API references

- [Suggested Bot Rights](https://core.telegram.org/api/rights#suggested-bot-rights)
- [Group Bot Links with admin param](https://core.telegram.org/api/links#group-channel-bot-links)

## Test plan

- [ ] Deploy and verify `setMyDefaultAdministratorRights` log on startup
- [ ] Create invitation via admin panel, verify `groupLink` is generated
- [ ] Click group link, verify Telegram proposes adding bot with admin rights
- [ ] Add bot to supergroup WITHOUT admin, verify improved warning with @username
- [ ] Backend type-check passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)