### PR TITLE
fix: Use github.request() for listing commit files

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -51,11 +51,12 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { data: files } = await github.rest.git.listCommitFiles({
+            const response = await github.request('GET /repos/{owner}/{repo}/commits/{commit_sha}/files', {
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha
             });
+            const files = response.data;
 
             const codePatterns = [
               'backend/', 'frontend/', 'package.json', 'pnpm-lock.yaml',


### PR DESCRIPTION
## Summary

Fixes the Release Please workflow error:
`TypeError: github.rest.git.listCommitFiles is not a function`

## Root Cause

The `actions/github-script@v7` uses Octokit, but the `listCommitFiles` method is not available as a direct REST method in the bundled Octokit version. The solution is to use `github.request()` which allows raw REST API calls.

## Changes

Changed the API call in `.github/workflows/release-please.yml` from:
```javascript
const { data: files } = await github.rest.git.listCommitFiles({...});
```

To:
```javascript
const response = await github.request('GET /repos/{owner}/{repo}/commits/{commit_sha}/files', {
  owner: context.repo.owner,
  repo: context.repo.repo,
  commit_sha: context.sha
});
const files = response.data;
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing

This fix was tested by verifying the GitHub Actions script syntax is correct.
