### PR TITLE
fix: Use gh CLI and correct workflow_run SHA

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,16 +26,21 @@ jobs:
         with:
           script: |
             // Wait for CI workflow to complete
+            // Use workflow_run event's head_sha for the commit
+            const headSha = context.payload.workflow_run.head_sha;
+            console.log('Checking CI for commit:', headSha);
+
             const { data: runs } = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: 'ci.yml',
-              head_sha: context.sha,
+              head_sha: headSha,
               status: 'completed',
               per_page: 1
             });
             if (runs.workflow_runs.length > 0) {
               const conclusion = runs.workflow_runs[0].conclusion;
+              console.log('CI conclusion:', conclusion);
               if (conclusion !== 'success') {
                 core.setFailed('CI workflow failed, skipping release');
               }


### PR DESCRIPTION
## Summary

Fixes the Release Please workflow error:
`TypeError: github.rest.git.listCommitFiles is not a function`

## Root Cause

Two issues were identified:

1. **Octokit API Issue**: The `actions/github-script@v7` uses Octokit, but `listCommitFiles` method is not available as a direct REST method. Using `github.request()` also has issues with path parameters.

2. **Wrong Context**: In a `workflow_run` trigger, `context.sha` doesn't point to the correct commit. It should use `context.payload.workflow_run.head_sha`.

## Changes

1. **Replaced JavaScript with `gh` CLI**: The check for commit files now uses `gh api` command which is more reliable:
   ```bash
   gh api repos/${{ github.repository }}/commits/$COMMIT_SHA/files
   ```

2. **Fixed commit SHA**: Changed from `context.sha` to `context.payload.workflow_run.head_sha` for the `workflow_run` trigger context.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Testing

This fix was tested by verifying the GitHub Actions script syntax is correct.
