### PR TITLE
fix: Add GH_TOKEN for gh CLI in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Check if code changed
         id: check-files
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Get the commit SHA from the workflow run event
           COMMIT_SHA=${{ github.event.workflow_run.head_sha }}


### PR DESCRIPTION
Adds the missing GH_TOKEN environment variable to the step that uses gh CLI in the release-please workflow.