### PR TITLE
fix(classifier): restore AI model, add fallback cascade and failure alerting

### DIFF
--- a/backend/src/bot/handlers/__tests__/response.handler.test.ts
+++ b/backend/src/bot/handlers/__tests__/response.handler.test.ts
@@ -776,7 +776,7 @@ describe('Response handler - alert resolution (step 7)', () => {
     registerResponseHandler();
   });
 
-  it('resolveAlertsForRequest is called with (requestId, "accountant_responded", telegramUserId as string)', async () => {
+  it('resolveAlertsForRequest is called with (requestId, "accountant_responded", accountantId UUID)', async () => {
     const ctx = buildResponseCtx({ telegramUserId: 44444 });
 
     await responseHandler(ctx);
@@ -784,7 +784,7 @@ describe('Response handler - alert resolution (step 7)', () => {
     expect(resolveAlertsForRequest).toHaveBeenCalledWith(
       'req-uuid-step7',
       'accountant_responded',
-      '44444'
+      'acc-uuid-123'
     );
   });
 

--- a/backend/src/bot/handlers/message.handler.ts
+++ b/backend/src/bot/handlers/message.handler.ts
@@ -5,10 +5,10 @@
  * 1. Filters for group/supergroup messages only
  * 2. Checks if SLA monitoring is enabled for the chat
  * 3. Classifies messages using AI/keyword classifier
- * 4. Creates ClientRequest records for REQUEST messages
+ * 4. Creates ClientRequest records for REQUEST and CLARIFICATION messages
  * 5. Starts SLA timer for tracking response time
  *
- * Non-REQUEST classifications (SPAM, GRATITUDE, CLARIFICATION) are logged
+ * Non-REQUEST classifications (SPAM, GRATITUDE) are logged
  * but do not trigger SLA tracking.
  *
  * @module bot/handlers/message.handler

--- a/backend/src/bot/handlers/response.handler.ts
+++ b/backend/src/bot/handlers/response.handler.ts
@@ -450,7 +450,7 @@ export function registerResponseHandler(): void {
         const resolvedCount = await resolveAlertsForRequest(
           requestToResolve.id,
           'accountant_responded',
-          telegramUserId ? String(telegramUserId) : undefined
+          accountantId ?? undefined
         );
         // Always cancel escalations — BullMQ jobs may exist even when no DB alerts remain
         await cancelAllEscalations(requestToResolve.id);

--- a/backend/src/queues/sla-timer.worker.ts
+++ b/backend/src/queues/sla-timer.worker.ts
@@ -104,7 +104,7 @@ async function processSlaTimer(job: Job<SlaTimerJobData>): Promise<void> {
         Prisma.sql`
           SELECT "id" FROM "public"."sla_alerts"
           WHERE "request_id" = ${requestId}
-            AND "alert_type" = 'warning'::"AlertType"
+            AND "alert_type"::text = 'warning'
             AND "escalation_level" = 0
             AND "resolved_action" IS NULL
           LIMIT 1

--- a/backend/src/services/classifier/__tests__/classifier.service.test.ts
+++ b/backend/src/services/classifier/__tests__/classifier.service.test.ts
@@ -397,7 +397,7 @@ describe('ClassifierService - Safety Net Integration (gh-131)', () => {
     service = new ClassifierService(mockPrisma);
   });
 
-  it('should default to CLARIFICATION when keyword result has confidence < 0.5 (threshold)', async () => {
+  it('should default to REQUEST when keyword result has confidence < 0.5 (threshold)', async () => {
     const { getCached } = await import('../cache.service.js');
     const { classifyWithAI } = await import('../openrouter-client.js');
     const { classifyByKeywords } = await import('../keyword-classifier.js');
@@ -413,19 +413,19 @@ describe('ClassifierService - Safety Net Integration (gh-131)', () => {
       classification: 'REQUEST',
       confidence: 0.3, // Below default keywordConfidenceThreshold (0.5)
       model: 'keyword-fallback',
-      reasoning: 'No patterns matched, requires human review',
+      reasoning: 'No patterns matched, defaulting to REQUEST for SLA safety',
     };
     (classifyByKeywords as any).mockReturnValue(lowConfidenceKeyword);
 
     // Classify message
     const result = await service.classifyMessage('test message');
 
-    // Should default to CLARIFICATION with threshold confidence (0.5)
+    // Should default to REQUEST with threshold confidence (0.5)
     expect(result).toMatchObject({
-      classification: 'CLARIFICATION',
+      classification: 'REQUEST',
       confidence: 0.5,
       model: 'keyword-fallback',
-      reasoning: 'Low confidence classification, defaulting to CLARIFICATION for manual review',
+      reasoning: 'Low confidence classification, defaulting to REQUEST for SLA safety',
     });
   });
 
@@ -474,10 +474,10 @@ describe('ClassifierService - Safety Net Integration (gh-131)', () => {
 
     // Mock keyword result with default no-match confidence (0.3)
     const noMatchKeyword: ClassificationResult = {
-      classification: 'CLARIFICATION',
+      classification: 'REQUEST',
       confidence: 0.3,
       model: 'keyword-fallback',
-      reasoning: 'No patterns matched, requires human review',
+      reasoning: 'No patterns matched, defaulting to REQUEST for SLA safety',
     };
     (classifyByKeywords as any).mockReturnValue(noMatchKeyword);
 
@@ -486,10 +486,10 @@ describe('ClassifierService - Safety Net Integration (gh-131)', () => {
 
     // Should apply safety net and boost confidence to threshold
     expect(result).toMatchObject({
-      classification: 'CLARIFICATION',
+      classification: 'REQUEST',
       confidence: 0.5, // Boosted to keywordConfidenceThreshold
       model: 'keyword-fallback',
-      reasoning: 'Low confidence classification, defaulting to CLARIFICATION for manual review',
+      reasoning: 'Low confidence classification, defaulting to REQUEST for SLA safety',
     });
   });
 

--- a/backend/src/services/classifier/__tests__/keyword-classifier.test.ts
+++ b/backend/src/services/classifier/__tests__/keyword-classifier.test.ts
@@ -332,44 +332,44 @@ describe('classifyByKeywords - Priority system', () => {
   });
 });
 
-describe('classifyByKeywords - Safety net (default CLARIFICATION)', () => {
-  it('should return CLARIFICATION with confidence 0.3 when no patterns match', () => {
+describe('classifyByKeywords - Safety net (default REQUEST)', () => {
+  it('should return REQUEST with confidence 0.3 when no patterns match', () => {
     // Message with no matching patterns
     const result = classifyByKeywords('Просто обычное сообщение без триггеров');
 
     expect(result).toMatchObject({
-      classification: 'CLARIFICATION',
+      classification: 'REQUEST',
       confidence: 0.3,
       model: 'keyword-fallback',
-      reasoning: 'No patterns matched, requires human review',
+      reasoning: 'No patterns matched, defaulting to REQUEST for SLA safety',
     });
   });
 
-  it('should return CLARIFICATION for random text', () => {
+  it('should return REQUEST for random text', () => {
     const result = classifyByKeywords('Lorem ipsum dolor sit amet');
 
     expect(result).toMatchObject({
-      classification: 'CLARIFICATION',
+      classification: 'REQUEST',
       confidence: 0.3,
       model: 'keyword-fallback',
     });
   });
 
-  it('should return CLARIFICATION for empty-looking message', () => {
+  it('should return REQUEST for empty-looking message', () => {
     const result = classifyByKeywords('   ');
 
     expect(result).toMatchObject({
-      classification: 'CLARIFICATION',
+      classification: 'REQUEST',
       confidence: 0.3,
       model: 'keyword-fallback',
     });
   });
 
-  it('should return CLARIFICATION for message with no clear intent', () => {
+  it('should return REQUEST for message with no clear intent', () => {
     const result = classifyByKeywords('Текст без ясного намерения');
 
     expect(result).toMatchObject({
-      classification: 'CLARIFICATION',
+      classification: 'REQUEST',
       confidence: 0.3,
       model: 'keyword-fallback',
     });

--- a/backend/src/services/classifier/classifier.service.ts
+++ b/backend/src/services/classifier/classifier.service.ts
@@ -39,6 +39,8 @@ import {
 export class ClassifierService {
   private prisma: PrismaClient;
   private config: ClassifierConfig;
+  private lastAlertTimestamp = 0;
+  private readonly ALERT_COOLDOWN_MS = 5 * 60 * 1000; // 5 min cooldown
   private settingsCache: {
     apiKey?: string;
     model?: string;
@@ -260,9 +262,15 @@ export class ClassifierService {
       const errorType = this.categorizeError(error);
       classifierErrorsTotal.inc({ error_type: errorType });
 
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      const modelName = dbSettings.model ?? this.config.openRouterModel;
+
+      // Send alert to lead notification recipients (rate-limited)
+      await this.sendClassifierFailureAlert(errorMsg, modelName);
+
       // AI classification failed, use fallback
       logger.warn('AI classification failed, using keyword fallback', {
-        error: error instanceof Error ? error.message : String(error),
+        error: errorMsg,
         service: 'classifier',
       });
     }
@@ -288,12 +296,12 @@ export class ClassifierService {
       finalResult.model === 'keyword-fallback' &&
       finalResult.confidence < this.config.keywordConfidenceThreshold
     ) {
-      // Very low confidence - default to CLARIFICATION (logged but no SLA timer)
+      // Very low confidence - default to REQUEST (starts SLA timer, false positive safer than missed breach)
       finalResult = {
-        classification: 'CLARIFICATION',
+        classification: 'REQUEST',
         confidence: this.config.keywordConfidenceThreshold,
         model: 'keyword-fallback',
-        reasoning: 'Low confidence classification, defaulting to CLARIFICATION for manual review',
+        reasoning: 'Low confidence classification, defaulting to REQUEST for SLA safety',
       };
     }
 
@@ -317,6 +325,50 @@ export class ClassifierService {
     });
 
     return finalResult;
+  }
+
+  /**
+   * Send alert to lead notification recipients when AI classification is down
+   * Rate-limited to one alert per ALERT_COOLDOWN_MS (5 minutes)
+   */
+  private async sendClassifierFailureAlert(errorMsg: string, model: string): Promise<void> {
+    const now = Date.now();
+    if (now - this.lastAlertTimestamp < this.ALERT_COOLDOWN_MS) return;
+    this.lastAlertTimestamp = now;
+
+    try {
+      const settings = await this.prisma.globalSettings.findUnique({
+        where: { id: 'default' },
+        select: { leadNotificationIds: true },
+      });
+      const recipients = settings?.leadNotificationIds ?? [];
+      if (recipients.length === 0) return;
+
+      const { bot } = await import('../../bot/bot.js');
+      const { escapeHtml } = await import('../../services/alerts/format.service.js');
+
+      const alertText =
+        `⚠️ <b>BuhBot: AI-классификатор недоступен</b>\n\n` +
+        `Модель: <code>${escapeHtml(model)}</code>\n` +
+        `Ошибка: <code>${escapeHtml(errorMsg.slice(0, 200))}</code>\n` +
+        `Используется keyword fallback (дефолт: REQUEST).\n\n` +
+        `Время: ${new Date().toLocaleString('ru-RU', { timeZone: 'Europe/Moscow' })}`;
+
+      for (const recipientId of recipients) {
+        await bot.telegram.sendMessage(recipientId, alertText, { parse_mode: 'HTML' });
+      }
+
+      logger.warn('Classifier failure alert sent', {
+        recipients: recipients.length,
+        model,
+        service: 'classifier',
+      });
+    } catch (alertErr) {
+      logger.error('Failed to send classifier failure alert', {
+        error: alertErr instanceof Error ? alertErr.message : String(alertErr),
+        service: 'classifier',
+      });
+    }
   }
 
   /**

--- a/backend/src/services/classifier/keyword-classifier.ts
+++ b/backend/src/services/classifier/keyword-classifier.ts
@@ -213,18 +213,18 @@ export function classifyByKeywords(text: string): ClassificationResult {
     }
   }
 
-  // No matches - default to CLARIFICATION (safe default requiring human review)
+  // No matches - default to REQUEST (safe default: starts SLA timer, false positive safer than missed breach)
   if (categoryScores.size === 0) {
-    logger.debug('No keyword patterns matched, defaulting to CLARIFICATION', {
+    logger.debug('No keyword patterns matched, defaulting to REQUEST', {
       text: text.substring(0, 50),
       service: 'classifier',
     });
 
     return {
-      classification: 'CLARIFICATION',
+      classification: 'REQUEST',
       confidence: 0.3,
       model: 'keyword-fallback',
-      reasoning: 'No patterns matched, requires human review',
+      reasoning: 'No patterns matched, defaulting to REQUEST for SLA safety',
     };
   }
 

--- a/backend/src/services/classifier/openrouter-client.ts
+++ b/backend/src/services/classifier/openrouter-client.ts
@@ -326,6 +326,61 @@ class OpenRouterClient {
       }
     }
 
+    // Fallback model attempt: try once with a different model before giving up
+    if (
+      this.config.fallbackModel &&
+      this.config.fallbackModel !== this.config.openRouterModel &&
+      lastError
+    ) {
+      try {
+        logger.warn('Attempting fallback model classification', {
+          fallbackModel: this.config.fallbackModel,
+          primaryModel: this.config.openRouterModel,
+          service: 'classifier',
+        });
+
+        const fallbackResponse = await this.client.chat.completions.create({
+          model: this.config.fallbackModel,
+          messages: [
+            { role: 'system', content: CLASSIFICATION_PROMPT },
+            { role: 'user', content: text },
+          ],
+          temperature: 0.1,
+          max_tokens: 150,
+        });
+
+        const fallbackContent = fallbackResponse.choices[0]?.message?.content;
+        if (!fallbackContent) {
+          throw new EmptyResponseError('Empty response from fallback model');
+        }
+
+        const parsed = parseAIResponse(fallbackContent);
+
+        logger.warn('Fallback model classification successful', {
+          classification: parsed.classification,
+          confidence: parsed.confidence,
+          fallbackModel: this.config.fallbackModel,
+          service: 'classifier',
+        });
+
+        this.circuitBreaker.recordSuccess();
+
+        return {
+          classification: parsed.classification,
+          confidence: parsed.confidence,
+          model: 'openrouter',
+          reasoning: `[fallback: ${this.config.fallbackModel}] ${parsed.reasoning}`,
+        };
+      } catch (fallbackError) {
+        logger.error('Fallback model classification also failed', {
+          fallbackModel: this.config.fallbackModel,
+          error: fallbackError instanceof Error ? fallbackError.message : String(fallbackError),
+          service: 'classifier',
+        });
+        // Fall through to throw original lastError
+      }
+    }
+
     // Should not reach here, but TypeScript needs the throw
     throw lastError ?? new Error('Classification failed after max retries');
   }

--- a/backend/src/services/classifier/types.ts
+++ b/backend/src/services/classifier/types.ts
@@ -62,6 +62,8 @@ export interface ClassifierConfig {
   timeoutMs: number;
   /** Maximum retry attempts for API calls (default: 3) */
   maxRetries: number;
+  /** Fallback OpenRouter model when primary fails (default: google/gemini-2.0-flash-001) */
+  fallbackModel: string;
   /** Circuit breaker configuration */
   circuitBreaker?: CircuitBreakerConfig;
 }
@@ -74,6 +76,7 @@ export const DEFAULT_CLASSIFIER_CONFIG: ClassifierConfig = {
   keywordConfidenceThreshold: 0.5,
   cacheTTLHours: 24,
   openRouterModel: 'xiaomi/mimo-v2-flash',
+  fallbackModel: 'google/gemini-2.0-flash-001',
   timeoutMs: 30000,
   maxRetries: 3,
 };


### PR DESCRIPTION
## Summary

- **Bug 1 (P1)**: AI классификатор использовал сломанную модель `openai/gpt-oss-120b` (миграция 20260221 не обновила существующую запись в DB). ~47% сообщений попадали в keyword fallback → CLARIFICATION → без SLA-мониторинга.
  - Restored `xiaomi/mimo-v2-flash` в production DB
  - Added fallback model `google/gemini-2.0-flash-001` (попытка 1 раз после исчерпания retries primary)
  - Added rate-limited Telegram alerting to `lead_notification_ids` при полном отказе AI
  - Changed keyword fallback default: CLARIFICATION → REQUEST (SLA safety)

- **Bug 2 (P2)**: Alert resolution передавал Telegram user ID вместо UUID в `sla_alerts.acknowledged_by` → алерты не резолвились при ответе бухгалтера.
  - Fixed: используем `accountantId` (UUID из `isAccountantForChat()`)

- **Bug 3 (P2)**: Prisma 7 enum cast bug в SLA warning idempotency check → warning jobs падали.
  - Fixed: `alert_type::text = 'warning'` вместо `alert_type = 'warning'::"AlertType"`

## Test plan

- [x] TypeScript type check passes
- [x] 66 classifier tests pass (keyword, circuit-breaker, service)
- [ ] E2E: send test message → verify `classification_model = 'openrouter'`
- [ ] E2E: send test message → SLA alert fires after threshold
- [ ] Verify Telegram alert on AI failure (temporarily break model)
- [ ] Verify accountant response resolves SLA alerts without UUID error

Closes: buh-j62x, buh-rx2n, buh-b5dq, buh-h61s

🤖 Generated with [Claude Code](https://claude.com/claude-code)