### PR TITLE
fix(alerts): resolve Telegram ID to UUID in alert callback handler

### DIFF
--- a/backend/src/bot/handlers/__tests__/alert-callback.handler.behavior.test.ts
+++ b/backend/src/bot/handlers/__tests__/alert-callback.handler.behavior.test.ts
@@ -29,6 +29,7 @@ const {
       },
       user: {
         findMany: vi.fn(),
+        findFirst: vi.fn(),
       },
       slaAlert: {
         update: vi.fn(),
@@ -143,6 +144,7 @@ describe('alert-callback handler registered actions', () => {
     });
     mockPrisma.slaAlert.update.mockResolvedValue({ id: ALERT_ID });
     mockPrisma.clientRequest.update.mockResolvedValue({ id: 'request-uuid' });
+    mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-resolved' });
     vi.mocked(cancelEscalation).mockResolvedValue(undefined);
     vi.mocked(cancelAllEscalations).mockResolvedValue(undefined);
     registerAlertCallbackHandler();
@@ -362,6 +364,7 @@ describe('isAuthorizedForAlertAction — allowAccountants: false (notify_* handl
     registeredActions.length = 0;
     mockBot.telegram.sendMessage.mockResolvedValue({ message_id: 123 });
     mockPrisma.user.findMany.mockResolvedValue([]);
+    mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-resolved' });
     vi.mocked(cancelEscalation).mockResolvedValue(undefined);
     vi.mocked(cancelAllEscalations).mockResolvedValue(undefined);
     registerAlertCallbackHandler();
@@ -484,6 +487,7 @@ describe('isAuthorizedForAlertAction — allowAccountants: true (resolve_* handl
     });
     mockPrisma.slaAlert.update.mockResolvedValue({ id: ALERT_ID });
     mockPrisma.clientRequest.update.mockResolvedValue({ id: 'request-uuid' });
+    mockPrisma.user.findFirst.mockResolvedValue({ id: 'user-uuid-resolved' });
     vi.mocked(cancelEscalation).mockResolvedValue(undefined);
     vi.mocked(cancelAllEscalations).mockResolvedValue(undefined);
     registerAlertCallbackHandler();

--- a/backend/src/bot/handlers/alert-callback.handler.ts
+++ b/backend/src/bot/handlers/alert-callback.handler.ts
@@ -362,7 +362,17 @@ export function registerAlertCallbackHandler(): void {
   // Handle "Mark resolved" button
   bot.action(/^resolve_(.+)$/, async (ctx) => {
     const alertId = ctx.match[1];
-    const userId = ctx.from?.id?.toString();
+    const telegramUserId = ctx.from?.id;
+
+    // Resolve Telegram ID → user UUID for acknowledgedBy FK
+    let userId: string | undefined;
+    if (telegramUserId) {
+      const user = await prisma.user.findFirst({
+        where: { telegramId: BigInt(telegramUserId) },
+        select: { id: true },
+      });
+      userId = user?.id;
+    }
 
     if (!alertId || !UUID_REGEX.test(alertId)) {
       await ctx.answerCbQuery('Некорректные данные');
@@ -372,6 +382,7 @@ export function registerAlertCallbackHandler(): void {
     logger.info('Resolve alert callback received', {
       alertId,
       userId,
+      telegramUserId,
       service: 'alert-callback',
     });
 


### PR DESCRIPTION
## Summary

Кнопка «Отметить решённым» в SLA-алерте падала с ошибкой `invalid input syntax for type uuid: "869709142"`. Причина: `ctx.from.id` (Telegram ID) передавался в `sla_alerts.acknowledged_by` (UUID FK).

Фикс: резолвим Telegram ID → `users.id` через DB lookup (тот же паттерн, что в response.handler.ts).

## Test plan

- [ ] Нажать «Отметить решённым» на SLA-алерте → должно работать без ошибки

🤖 Generated with [Claude Code](https://claude.com/claude-code)