### PR TITLE
fix(classifier): code review findings — shadowing, circuit breaker, metrics, tests

### DIFF
--- a/backend/src/api/trpc/routers/sla.ts
+++ b/backend/src/api/trpc/routers/sla.ts
@@ -357,7 +357,9 @@ export const slaRouter = router({
         model:
           result.model === 'cache' || result.model === 'error-fallback'
             ? 'keyword-fallback'
-            : result.model,
+            : result.model === 'openrouter-fallback'
+              ? 'openrouter'
+              : result.model,
         reasoning: result.reasoning,
       };
     }),

--- a/backend/src/bot/handlers/alert-callback.handler.ts
+++ b/backend/src/bot/handlers/alert-callback.handler.ts
@@ -364,16 +364,6 @@ export function registerAlertCallbackHandler(): void {
     const alertId = ctx.match[1];
     const telegramUserId = ctx.from?.id;
 
-    // Resolve Telegram ID → user UUID for acknowledgedBy FK
-    let userId: string | undefined;
-    if (telegramUserId) {
-      const user = await prisma.user.findFirst({
-        where: { telegramId: BigInt(telegramUserId) },
-        select: { id: true },
-      });
-      userId = user?.id;
-    }
-
     if (!alertId || !UUID_REGEX.test(alertId)) {
       await ctx.answerCbQuery('Некорректные данные');
       return;
@@ -381,7 +371,6 @@ export function registerAlertCallbackHandler(): void {
 
     logger.info('Resolve alert callback received', {
       alertId,
-      userId,
       telegramUserId,
       service: 'alert-callback',
     });
@@ -421,16 +410,25 @@ export function registerAlertCallbackHandler(): void {
       }
 
       // Authorization: resolve is manager-or-accountant (gh-88)
-      const telegramUserId = ctx.from?.id;
       if (!telegramUserId || !(await isAuthorizedForAlertAction(request.chatId, telegramUserId))) {
         logger.warn('Unauthorized alert resolve attempt', {
           alertId,
-          userId,
+          telegramUserId,
           chatId: String(request.chatId),
           service: 'alert-callback',
         });
         await ctx.answerCbQuery('Нет прав для этого действия');
         return;
+      }
+
+      // Resolve Telegram ID → user UUID for acknowledgedBy FK (after all validation)
+      let userId: string | undefined;
+      if (telegramUserId) {
+        const user = await prisma.user.findFirst({
+          where: { telegramId: BigInt(telegramUserId) },
+          select: { id: true },
+        });
+        userId = user?.id;
       }
 
       if (request.status === 'answered') {
@@ -544,7 +542,7 @@ export function registerAlertCallbackHandler(): void {
         error: error instanceof Error ? error.message : String(error),
         stack: error instanceof Error ? error.stack : undefined,
         alertId,
-        userId,
+        telegramUserId,
         service: 'alert-callback',
       });
       const msg = error instanceof Error ? error.message : '';

--- a/backend/src/services/classifier/__tests__/classifier.service.test.ts
+++ b/backend/src/services/classifier/__tests__/classifier.service.test.ts
@@ -59,8 +59,25 @@ vi.mock('../cache.service.js', () => ({
   getCacheStats: vi.fn(),
 }));
 
+// Mock bot (used by sendClassifierFailureAlert via dynamic import in classifier.service.ts)
+// Path is relative to THIS test file: __tests__/ → ../../../bot/bot.ts
+const mockSendMessage = vi.fn();
+vi.mock('../../../bot/bot.js', () => ({
+  bot: { telegram: { sendMessage: mockSendMessage } },
+}));
+
+// Mock escapeHtml from format service
+// Path relative to this file: __tests__/ → ../alerts/format.service.ts
+vi.mock('../alerts/format.service.js', () => ({
+  escapeHtml: (s: string) => s,
+}));
+
 // Mock Prisma client
-const mockPrisma = {} as PrismaClient;
+const mockPrisma = {
+  globalSettings: {
+    findUnique: vi.fn(),
+  },
+} as unknown as PrismaClient;
 
 describe('ClassifierService - Error Categorization (T3)', () => {
   let service: ClassifierService;
@@ -68,6 +85,7 @@ describe('ClassifierService - Error Categorization (T3)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetClassifierService();
+    (mockPrisma.globalSettings.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
     service = new ClassifierService(mockPrisma);
   });
 
@@ -183,6 +201,7 @@ describe('ClassifierService - Metrics Recording (T4)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetClassifierService();
+    (mockPrisma.globalSettings.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
     service = new ClassifierService(mockPrisma);
   });
 
@@ -394,6 +413,8 @@ describe('ClassifierService - Safety Net Integration (gh-131)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetClassifierService();
+    // Reset prisma mock for tests that don't need it
+    (mockPrisma.globalSettings.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
     service = new ClassifierService(mockPrisma);
   });
 
@@ -527,5 +548,155 @@ describe('ClassifierService - Safety Net Integration (gh-131)', () => {
     expect(result.confidence).toBe(0.55);
     expect(result.model).toBe('openrouter'); // Note: service might wrap this, check actual implementation
     expect(result.reasoning).toContain('AI (low confidence: 0.55)');
+  });
+});
+
+describe('ClassifierService - Failure Alerting (H-2)', () => {
+  let service: ClassifierService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset implementations so that Once queues from previous tests don't leak
+    mockSendMessage.mockReset();
+    (mockPrisma.globalSettings.findUnique as ReturnType<typeof vi.fn>).mockReset();
+    resetClassifierService();
+    // Default: no DB settings returned (settings cache miss)
+    (mockPrisma.globalSettings.findUnique as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+    service = new ClassifierService(mockPrisma);
+  });
+
+  it('should send alert when AI fails and cooldown has elapsed', async () => {
+    const { getCached } = await import('../cache.service.js');
+    const { classifyWithAI } = await import('../openrouter-client.js');
+    const { classifyByKeywords } = await import('../keyword-classifier.js');
+
+    // Mock cache miss
+    (getCached as any).mockResolvedValue(null);
+
+    // Mock AI failure
+    (classifyWithAI as any).mockRejectedValue(new Error('AI service down'));
+
+    // Mock keyword fallback
+    (classifyByKeywords as any).mockReturnValue({
+      classification: 'REQUEST',
+      confidence: 0.6,
+      model: 'keyword-fallback',
+    });
+
+    // On the second findUnique call (inside sendClassifierFailureAlert) return recipients
+    (mockPrisma.globalSettings.findUnique as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(null) // getDbSettings call
+      .mockResolvedValueOnce({ leadNotificationIds: [111, 222] }); // sendClassifierFailureAlert call
+
+    // mockSendMessage is already set up via vi.mock at module level
+    mockSendMessage.mockResolvedValue(undefined);
+
+    // Classify — this triggers sendClassifierFailureAlert internally
+    await service.classifyMessage('test message');
+
+    // Alert should have been sent to both recipients
+    expect(mockSendMessage).toHaveBeenCalledTimes(2);
+    expect(mockSendMessage).toHaveBeenCalledWith(111, expect.stringContaining('BuhBot'), {
+      parse_mode: 'HTML',
+    });
+    expect(mockSendMessage).toHaveBeenCalledWith(222, expect.stringContaining('BuhBot'), {
+      parse_mode: 'HTML',
+    });
+  });
+
+  it('should NOT send alert when called within 5-minute cooldown window', async () => {
+    const { getCached } = await import('../cache.service.js');
+    const { classifyWithAI } = await import('../openrouter-client.js');
+    const { classifyByKeywords } = await import('../keyword-classifier.js');
+
+    mockSendMessage.mockResolvedValue(undefined);
+
+    (getCached as any).mockResolvedValue(null);
+    (classifyWithAI as any).mockRejectedValue(new Error('AI service down'));
+    (classifyByKeywords as any).mockReturnValue({
+      classification: 'REQUEST',
+      confidence: 0.6,
+      model: 'keyword-fallback',
+    });
+
+    // Both getDbSettings and sendClassifierFailureAlert calls return recipients
+    (mockPrisma.globalSettings.findUnique as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(null) // getDbSettings (first classifyMessage)
+      .mockResolvedValueOnce({ leadNotificationIds: [111] }) // sendClassifierFailureAlert (first)
+      .mockResolvedValueOnce(null); // getDbSettings (second classifyMessage) — alert body not reached due to cooldown
+
+    // First call — alert should be sent
+    await service.classifyMessage('first message');
+    const callsAfterFirst = mockSendMessage.mock.calls.length;
+
+    // Second call immediately (within 5-minute window) — alert rate-limited
+    (getCached as any).mockResolvedValue(null);
+    (classifyWithAI as any).mockRejectedValue(new Error('AI service down'));
+    (classifyByKeywords as any).mockReturnValue({
+      classification: 'REQUEST',
+      confidence: 0.6,
+      model: 'keyword-fallback',
+    });
+    await service.classifyMessage('second message');
+
+    // No additional sendMessage calls from second classify
+    expect(mockSendMessage.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it('should silently skip when no recipients are configured', async () => {
+    const { getCached } = await import('../cache.service.js');
+    const { classifyWithAI } = await import('../openrouter-client.js');
+    const { classifyByKeywords } = await import('../keyword-classifier.js');
+
+    mockSendMessage.mockResolvedValue(undefined);
+
+    (getCached as any).mockResolvedValue(null);
+    (classifyWithAI as any).mockRejectedValue(new Error('AI service down'));
+    (classifyByKeywords as any).mockReturnValue({
+      classification: 'REQUEST',
+      confidence: 0.6,
+      model: 'keyword-fallback',
+    });
+
+    // sendClassifierFailureAlert gets empty recipients list
+    (mockPrisma.globalSettings.findUnique as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(null) // getDbSettings
+      .mockResolvedValueOnce({ leadNotificationIds: [] }); // sendClassifierFailureAlert
+
+    // Should complete without error and without sending messages
+    await expect(service.classifyMessage('test message')).resolves.toBeDefined();
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('should catch and log error when Telegram sendMessage throws', async () => {
+    const { getCached } = await import('../cache.service.js');
+    const { classifyWithAI } = await import('../openrouter-client.js');
+    const { classifyByKeywords } = await import('../keyword-classifier.js');
+    const logger = await import('../../../utils/logger.js');
+
+    // Make sendMessage throw a Telegram error
+    mockSendMessage.mockRejectedValue(new Error('Telegram API error'));
+
+    (getCached as any).mockResolvedValue(null);
+    (classifyWithAI as any).mockRejectedValue(new Error('AI service down'));
+    (classifyByKeywords as any).mockReturnValue({
+      classification: 'REQUEST',
+      confidence: 0.6,
+      model: 'keyword-fallback',
+    });
+
+    // Recipients configured so sendMessage gets called
+    (mockPrisma.globalSettings.findUnique as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(null) // getDbSettings
+      .mockResolvedValueOnce({ leadNotificationIds: [111] }); // sendClassifierFailureAlert
+
+    // Should NOT propagate Telegram error — classifyMessage must still return a result
+    await expect(service.classifyMessage('test message')).resolves.toBeDefined();
+
+    // Error should have been logged
+    expect(logger.default.error as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      'Failed to send classifier failure alert',
+      expect.objectContaining({ error: 'Telegram API error' })
+    );
   });
 });

--- a/backend/src/services/classifier/__tests__/openrouter-client.test.ts
+++ b/backend/src/services/classifier/__tests__/openrouter-client.test.ts
@@ -1,0 +1,287 @@
+/**
+ * OpenRouterClient Fallback Model Tests (H-1)
+ *
+ * Tests for OpenRouterClient class in openrouter-client.ts
+ *
+ * H-1 - Fallback Model Tests:
+ * 1. Primary model fails all retries → fallback model succeeds → result has [fallback: model]
+ *    in reasoning; model is 'openrouter' (implementation detail)
+ * 2. Both primary and fallback fail → throws original (primary) error
+ * 3. Fallback model same as primary → fallback skipped, throws
+ * 4. Circuit breaker OPEN → fallback not attempted, throws immediately
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { OpenRouterClient } from '../openrouter-client.js';
+import type { ICircuitBreaker } from '../circuit-breaker.js';
+
+// Mock logger
+vi.mock('../../../utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock metrics (circuit breaker module uses these at construction time)
+vi.mock('../../../utils/metrics.js', () => ({
+  classifierRequestsTotal: { inc: vi.fn() },
+  classifierLatencySeconds: { observe: vi.fn() },
+  classifierErrorsTotal: { inc: vi.fn() },
+  classifierCacheHitsTotal: { inc: vi.fn() },
+  classifierCacheMissesTotal: { inc: vi.fn() },
+  classifierCircuitBreakerState: { set: vi.fn() },
+  classifierCircuitBreakerTripsTotal: { inc: vi.fn() },
+}));
+
+// Mock OpenAI SDK at module level.
+// IMPORTANT: vi.mock factory is hoisted before variable declarations.
+// Error subclasses must be defined INSIDE the factory to avoid TDZ errors.
+// The `create` function references `mockCreate` lazily so it can be configured
+// per test after vi.mock hoisting.
+vi.mock('openai', () => {
+  class RateLimitError extends Error {
+    status = 429;
+    constructor(msg = 'Rate limit') {
+      super(msg);
+      this.name = 'RateLimitError';
+    }
+  }
+  class InternalServerError extends Error {
+    constructor(msg = 'Server error') {
+      super(msg);
+      this.name = 'InternalServerError';
+    }
+  }
+  class APIConnectionError extends Error {
+    constructor(msg = 'Connection error') {
+      super(msg);
+      this.name = 'APIConnectionError';
+    }
+  }
+  class APIConnectionTimeoutError extends Error {
+    constructor(msg = 'Timeout') {
+      super(msg);
+      this.name = 'APIConnectionTimeoutError';
+    }
+  }
+
+  // Real constructor function so `new OpenAI(...)` works.
+  // Delegates to mockCreate lazily to avoid hoisting issues.
+  function MockOpenAI(this: any, _opts: unknown) {
+    this.chat = {
+      completions: {
+        create: (...args: unknown[]) => mockCreate(...args),
+      },
+    };
+  }
+  MockOpenAI.RateLimitError = RateLimitError;
+  MockOpenAI.InternalServerError = InternalServerError;
+  MockOpenAI.APIConnectionError = APIConnectionError;
+  MockOpenAI.APIConnectionTimeoutError = APIConnectionTimeoutError;
+
+  return { default: MockOpenAI };
+});
+
+// Declared after vi.mock (hoisting) but lazily referenced inside the factory
+const mockCreate = vi.fn();
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build a mock ICircuitBreaker that allows requests by default
+ */
+function makeCircuitBreaker(overrides: Partial<ICircuitBreaker> = {}): ICircuitBreaker {
+  return {
+    canRequest: vi.fn().mockReturnValue(true),
+    recordSuccess: vi.fn(),
+    recordFailure: vi.fn(),
+    getState: vi.fn().mockReturnValue('CLOSED'),
+    reset: vi.fn(),
+    ...overrides,
+  };
+}
+
+/**
+ * Build a valid AI JSON response string
+ */
+function makeAIResponse(
+  classification = 'REQUEST',
+  confidence = 0.9,
+  reasoning = 'test reasoning'
+): string {
+  return JSON.stringify({ classification, confidence, reasoning });
+}
+
+/**
+ * Build a mock chat completion response object
+ */
+function makeChatCompletion(content: string) {
+  return {
+    choices: [{ message: { content } }],
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('OpenRouterClient - Fallback Model (H-1)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset Once queues in addition to clearing call history
+    mockCreate.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should use fallback model when primary fails all retries and return reasoning prefixed with [fallback: model]', async () => {
+    const primaryModel = 'xiaomi/mimo-v2-flash';
+    const fallbackModel = 'google/gemini-2.0-flash-001';
+    const cb = makeCircuitBreaker();
+
+    const client = new OpenRouterClient(
+      {
+        openRouterApiKey: 'test-key',
+        openRouterModel: primaryModel,
+        fallbackModel,
+        maxRetries: 1, // single attempt; non-retryable error exits loop immediately
+      },
+      cb
+    );
+
+    // Primary fails with a generic (non-retryable) error — no sleep() involved
+    mockCreate
+      .mockRejectedValueOnce(new Error('Primary model unavailable'))
+      .mockResolvedValueOnce(
+        makeChatCompletion(makeAIResponse('SPAM', 0.85, 'fallback reasoning'))
+      );
+
+    const result = await client.classify('test message');
+
+    expect(result.model).toBe('openrouter-fallback');
+    expect(result.reasoning).toContain(`[fallback: ${fallbackModel}]`);
+    expect(result.reasoning).toContain('fallback reasoning');
+    expect(result.classification).toBe('SPAM');
+    expect(result.confidence).toBe(0.85);
+
+    // Primary called first, fallback called second
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(mockCreate.mock.calls[0][0].model).toBe(primaryModel);
+    expect(mockCreate.mock.calls[1][0].model).toBe(fallbackModel);
+  });
+
+  it('should throw original (primary) error when both primary and fallback fail', async () => {
+    const primaryModel = 'xiaomi/mimo-v2-flash';
+    const fallbackModel = 'google/gemini-2.0-flash-001';
+    const cb = makeCircuitBreaker();
+
+    const client = new OpenRouterClient(
+      {
+        openRouterApiKey: 'test-key',
+        openRouterModel: primaryModel,
+        fallbackModel,
+        maxRetries: 1,
+      },
+      cb
+    );
+
+    mockCreate
+      .mockRejectedValueOnce(new Error('Primary model failed'))
+      .mockRejectedValueOnce(new Error('Fallback model also failed'));
+
+    // Should throw the ORIGINAL primary error, not the fallback error
+    await expect(client.classify('test message')).rejects.toThrow('Primary model failed');
+  });
+
+  it('should skip fallback and throw when fallback model is same as primary', async () => {
+    const model = 'xiaomi/mimo-v2-flash';
+    const cb = makeCircuitBreaker();
+
+    const client = new OpenRouterClient(
+      {
+        openRouterApiKey: 'test-key',
+        openRouterModel: model,
+        fallbackModel: model, // identical → fallback guard prevents attempt
+        maxRetries: 1,
+      },
+      cb
+    );
+
+    mockCreate.mockRejectedValueOnce(new Error('Primary model failed'));
+
+    await expect(client.classify('test message')).rejects.toThrow('Primary model failed');
+
+    // Only the single primary attempt; no fallback call
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it('should throw immediately when circuit breaker is OPEN, without attempting primary or fallback', async () => {
+    const cb = makeCircuitBreaker({
+      canRequest: vi.fn().mockReturnValue(false),
+      getState: vi.fn().mockReturnValue('OPEN'),
+    });
+
+    const client = new OpenRouterClient(
+      {
+        openRouterApiKey: 'test-key',
+        openRouterModel: 'xiaomi/mimo-v2-flash',
+        fallbackModel: 'google/gemini-2.0-flash-001',
+        maxRetries: 3,
+      },
+      cb
+    );
+
+    await expect(client.classify('test message')).rejects.toThrow(
+      'Circuit breaker OPEN - OpenRouter unavailable'
+    );
+
+    // No API calls at all
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it('should record circuit breaker success after fallback model succeeds', async () => {
+    const cb = makeCircuitBreaker();
+
+    const client = new OpenRouterClient(
+      {
+        openRouterApiKey: 'test-key',
+        openRouterModel: 'xiaomi/mimo-v2-flash',
+        fallbackModel: 'google/gemini-2.0-flash-001',
+        maxRetries: 1,
+      },
+      cb
+    );
+
+    mockCreate
+      .mockRejectedValueOnce(new Error('Primary failed'))
+      .mockResolvedValueOnce(makeChatCompletion(makeAIResponse('REQUEST', 0.9, 'ok')));
+
+    await client.classify('test message');
+
+    expect(cb.recordSuccess).toHaveBeenCalled();
+  });
+
+  it('should not attempt fallback when fallbackModel is empty string', async () => {
+    const cb = makeCircuitBreaker();
+
+    const client = new OpenRouterClient(
+      {
+        openRouterApiKey: 'test-key',
+        openRouterModel: 'xiaomi/mimo-v2-flash',
+        fallbackModel: '', // falsy → condition `this.config.fallbackModel && ...` is false
+        maxRetries: 1,
+      },
+      cb
+    );
+
+    mockCreate.mockRejectedValueOnce(new Error('Primary failed'));
+
+    await expect(client.classify('test message')).rejects.toThrow('Primary failed');
+
+    // Only 1 call — primary only, no fallback
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/services/classifier/openrouter-client.ts
+++ b/backend/src/services/classifier/openrouter-client.ts
@@ -322,15 +322,18 @@ class OpenRouterClient {
         }
 
         logger.error('AI classification failed', errorInfo);
-        throw lastError;
+        // Break instead of throw so fallback model can be attempted below
+        break;
       }
     }
 
     // Fallback model attempt: try once with a different model before giving up
+    // Only attempt if circuit breaker allows requests (H-3)
     if (
       this.config.fallbackModel &&
       this.config.fallbackModel !== this.config.openRouterModel &&
-      lastError
+      lastError &&
+      this.circuitBreaker.canRequest()
     ) {
       try {
         logger.warn('Attempting fallback model classification', {
@@ -368,7 +371,7 @@ class OpenRouterClient {
         return {
           classification: parsed.classification,
           confidence: parsed.confidence,
-          model: 'openrouter',
+          model: 'openrouter-fallback',
           reasoning: `[fallback: ${this.config.fallbackModel}] ${parsed.reasoning}`,
         };
       } catch (fallbackError) {

--- a/backend/src/services/classifier/types.ts
+++ b/backend/src/services/classifier/types.ts
@@ -16,7 +16,12 @@ export type MessageCategory = 'REQUEST' | 'SPAM' | 'GRATITUDE' | 'CLARIFICATION'
 /**
  * Classification source indicator
  */
-export type ClassificationSource = 'openrouter' | 'keyword-fallback' | 'cache' | 'error-fallback';
+export type ClassificationSource =
+  | 'openrouter'
+  | 'openrouter-fallback'
+  | 'keyword-fallback'
+  | 'cache'
+  | 'error-fallback';
 
 /**
  * Result of message classification


### PR DESCRIPTION
## Summary

Fixes from code review report (`docs/reports/code-review-sla-fix-2026-03-27.md`):

- **C-1**: Fix variable shadowing of `telegramUserId` in alert-callback resolve handler. Move UUID resolution after validation to avoid unnecessary DB queries for invalid requests.
- **H-1**: Add 6 unit tests for fallback model cascade in `openrouter-client.test.ts`
- **H-2**: Add 4 unit tests for Telegram failure alerting in `classifier.service.test.ts`
- **H-3**: Add circuit breaker `canRequest()` check before fallback model attempt
- **M-4**: Add `'openrouter-fallback'` to `ClassificationSource` for distinct Prometheus metrics
- **Bugfix**: Unreachable fallback code — `throw lastError` → `break` in retry loop

## Test plan

- [x] 141 tests pass (9 test files)
- [x] TypeScript type check clean
- [x] ESLint + Prettier pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)