### PR TITLE
fix(alerts): fix remaining Prisma 7 enum casts in alert queries

### DIFF
--- a/backend/src/api/trpc/routers/alert.ts
+++ b/backend/src/api/trpc/routers/alert.ts
@@ -556,12 +556,10 @@ export const alertRouter = router({
       if (input.alertType || input.deliveryStatus) {
         const enumConditions: Prisma.Sql[] = [];
         if (input.alertType) {
-          enumConditions.push(Prisma.sql`"alert_type" = ${input.alertType}::"AlertType"`);
+          enumConditions.push(Prisma.sql`"alert_type"::text = ${input.alertType}`);
         }
         if (input.deliveryStatus) {
-          enumConditions.push(
-            Prisma.sql`"delivery_status" = ${input.deliveryStatus}::"AlertDeliveryStatus"`
-          );
+          enumConditions.push(Prisma.sql`"delivery_status"::text = ${input.deliveryStatus}`);
         }
         const combinedCondition = Prisma.join(enumConditions, ' AND ');
         const matchingIds = await ctx.prisma.$queryRaw<Array<{ id: string }>>(

--- a/backend/src/services/alerts/alert.service.ts
+++ b/backend/src/services/alerts/alert.service.ts
@@ -100,7 +100,7 @@ export async function createAlert(params: CreateAlertParams): Promise<SlaAlert> 
       Prisma.sql`
         SELECT "id" FROM "public"."sla_alerts"
         WHERE "request_id" = ${requestId}
-          AND "alert_type" = ${alertType}::"AlertType"
+          AND "alert_type"::text = ${alertType}
           AND "escalation_level" = ${escalationLevel}
           AND "resolved_action" IS NULL
         LIMIT 1


### PR DESCRIPTION
## Summary

Fix 3 remaining Prisma 7 enum comparison bugs that cause `operator does not exist: text = "AlertType"` errors:
- `alert.service.ts:103` — alert idempotency check  
- `alert.ts:559` — alert_type filter
- `alert.ts:563` — delivery_status filter

Pattern: `column::text = value` instead of `column = value::"EnumType"`

## Test plan
- [x] TypeScript type check passes
- [ ] No more `prisma:error operator does not exist` in startup logs after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)