### PR TITLE
fix(alerts): auto-generate invite link + add chat details polling

### DIFF
--- a/backend/src/queues/alert.worker.ts
+++ b/backend/src/queues/alert.worker.ts
@@ -220,6 +220,28 @@ async function processSlaAlertJob(job: Job<ExtendedAlertJobData>): Promise<void>
       ...(globalSettings?.globalManagerIds ?? []),
     ]);
 
+    // Auto-generate invite link if missing (bot must be admin)
+    let inviteLink = request.chat?.inviteLink ?? null;
+    if (!inviteLink && request.chat?.id) {
+      try {
+        inviteLink = await bot.telegram.exportChatInviteLink(String(request.chat.id));
+        await prisma.chat.update({
+          where: { id: request.chat.id },
+          data: { inviteLink },
+        });
+        logger.info('Auto-generated invite link for chat', {
+          chatId: String(request.chat.id),
+          service: 'alert-worker',
+        });
+      } catch (linkErr) {
+        logger.debug('Could not generate invite link (bot may lack permissions)', {
+          chatId: String(request.chat.id),
+          error: linkErr instanceof Error ? linkErr.message : String(linkErr),
+          service: 'alert-worker',
+        });
+      }
+    }
+
     for (const recipientId of managerIds) {
       try {
         const showNotifyButton = !(
@@ -231,7 +253,7 @@ async function processSlaAlertJob(job: Job<ExtendedAlertJobData>): Promise<void>
                 alertId,
                 chatId,
                 requestId,
-                inviteLink: request.chat?.inviteLink,
+                inviteLink,
                 chatType: request.chat?.chatType,
               },
               {

--- a/frontend/src/components/chats/ChatDetailsContent.tsx
+++ b/frontend/src/components/chats/ChatDetailsContent.tsx
@@ -172,7 +172,14 @@ function ChatInfoCard({ chat }: ChatInfoCardProps) {
 
 export function ChatDetailsContent({ chatId }: ChatDetailsContentProps) {
   const [activeTab, setActiveTab] = React.useState<Tab>('messages');
-  const { data: chat, isLoading, error } = trpc.chats.getById.useQuery({ id: chatId });
+  const {
+    data: chat,
+    isLoading,
+    error,
+  } = trpc.chats.getById.useQuery(
+    { id: chatId },
+    { refetchInterval: 10_000, refetchIntervalInBackground: false }
+  );
   const utils = trpc.useUtils();
 
   // Restore mutation (gh-209)


### PR DESCRIPTION
## Summary

- **\"Открыть чат\" button fix**: Auto-generates Telegram invite link via `exportChatInviteLink` API when missing at alert send time. Stores in DB for future alerts. Requires bot admin permissions (already granted during `/connect`).
- **Frontend polling**: Adds 10s `refetchInterval` to chat details page so status updates (e.g. after "Mark resolved") appear without manual refresh.

## Test plan
- [ ] Send test message → alert has working "Открыть чат" button  
- [ ] Click "Отметить решённым" → chat details page auto-updates within 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)