### PR TITLE
ci: migrate docker/* GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,11 +183,14 @@ jobs:
           VERSION=$(jq -r '.version' package.json)
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      # gh-309: docker/* actions bumped to their Node 24 majors ahead of the
+      # 2026-06-02 deprecation deadline. v4/v7 require Actions Runner
+      # v2.327.1+ (hosted GitHub runners are already past that).
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3.6.0
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -198,7 +201,7 @@ jobs:
         run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./backend
           file: ./backend/Dockerfile
@@ -211,7 +214,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=backend
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./frontend/Dockerfile
@@ -229,7 +232,7 @@ jobs:
             NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
 
       - name: Build and push monitoring image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./infrastructure/monitoring
           file: ./infrastructure/monitoring/Dockerfile


### PR DESCRIPTION
Ref #309.

> Status: **In Sprint** · DRAFT

## Summary

GitHub deprecated Node 20 on JavaScript actions (forced to Node 24 on **2026-06-02**, removed 2026-09-16). The \`docker/*\` actions we use have already shipped Node 24 majors as direct, drop-in replacements.

## Version bumps in \`.github/workflows/ci.yml\`

| Action | Before | After | Released |
|---|---|---|---|
| \`docker/setup-buildx-action\` | \`@v3\` | \`@v4\` | 2026-03-05 |
| \`docker/login-action\` | \`@v3.6.0\` | \`@v4\` | 2026-03-04 |
| \`docker/build-push-action\` ×3 | \`@v6\` | \`@v7\` | 2026-03-05 |

All three v4/v7 releases explicitly advertise **"Node 24 as default runtime"** and require Actions Runner v2.327.1+ (hosted GitHub runners are already past that).

Only \`ci.yml\` uses these actions. \`deploy.yml\`, \`deploy-staging.yml\`, and other workflows do not reference \`docker/*\` actions.

## No behavior change

Same inputs/outputs between the previous and new major for our use cases (standard buildx setup, ghcr.io login, buildx build-and-push with GHA cache). CI on this PR will exercise the bump end-to-end.

## Test Plan

- [x] grep verified no other workflows use docker/* actions
- [ ] CI "Build Docker Images" job passes on this PR (backend, frontend, monitoring images build and push)
- [ ] No new deprecation warnings in the CI run logs

## Plan

- [x] Status \`In Sprint\` — this Draft PR
- [ ] Status \`In Review\` — after CI green
- [ ] Status \`In QA\` — after merge to dev/stage (trivially: if CI passes, accept)
- [ ] Merge to main → closes #309 via commit message

🤖 Generated with [Claude Code](https://claude.com/claude-code)