### PR TITLE
fix(feedback): unify /feedback read path on surveyVote (gh-324)

### DIFF
--- a/backend/src/api/trpc/context.ts
+++ b/backend/src/api/trpc/context.ts
@@ -116,6 +116,9 @@ function extractToken(authHeader: string | undefined): string | null {
 export async function createContext({ req }: CreateExpressContextOptions): Promise<Context> {
   const reqId = Math.random().toString(36).substring(7);
   const startTime = Date.now();
+  const requestHeaders = {
+    telegramSecretToken: req.headers['x-telegram-bot-api-secret-token'] as string | undefined,
+  };
 
   // DEV MODE: Bypass all authentication
   if (isDevMode) {
@@ -130,9 +133,7 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
         accessToken: 'dev-mode-token',
         expiresAt: Math.floor(Date.now() / 1000) + 86400, // 24 hours
       },
-      requestHeaders: {
-        telegramSecretToken: req.headers['x-telegram-bot-api-secret-token'] as string | undefined,
-      },
+      requestHeaders,
     };
   }
 
@@ -148,9 +149,7 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
       prisma,
       user: null,
       session: null,
-      requestHeaders: {
-        telegramSecretToken: req.headers['x-telegram-bot-api-secret-token'] as string | undefined,
-      },
+      requestHeaders,
     };
   }
 
@@ -161,9 +160,7 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
       prisma,
       user: null,
       session: null,
-      requestHeaders: {
-        telegramSecretToken: req.headers['x-telegram-bot-api-secret-token'] as string | undefined,
-      },
+      requestHeaders,
     };
   }
 
@@ -183,6 +180,7 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
         prisma,
         user: null,
         session: null,
+        requestHeaders,
       };
     }
 
@@ -210,6 +208,7 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
         prisma,
         user: null,
         session: null,
+        requestHeaders,
       };
     }
 
@@ -230,6 +229,7 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
         // Default to current time + 1 hour if no exp claim available
         expiresAt: Math.floor(Date.now() / 1000) + 3600,
       },
+      requestHeaders,
     };
   } catch (error) {
     // Log error for debugging (production: use structured logging)
@@ -243,9 +243,7 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
       prisma,
       user: null,
       session: null,
-      requestHeaders: {
-        telegramSecretToken: req.headers['x-telegram-bot-api-secret-token'] as string | undefined,
-      },
+      requestHeaders,
     };
   }
 }

--- a/backend/src/api/trpc/context.ts
+++ b/backend/src/api/trpc/context.ts
@@ -71,7 +71,7 @@ export interface Context {
   user: ContextUser | null; // Authenticated user (null if unauthenticated)
   session: ContextSession | null; // Session info (null if unauthenticated)
   requestHeaders?: {
-    telegramSecretToken?: string;
+    telegramSecretToken?: string | undefined;
   };
 }
 

--- a/backend/src/api/trpc/context.ts
+++ b/backend/src/api/trpc/context.ts
@@ -70,6 +70,9 @@ export interface Context {
   prisma: PrismaClient; // Database client
   user: ContextUser | null; // Authenticated user (null if unauthenticated)
   session: ContextSession | null; // Session info (null if unauthenticated)
+  requestHeaders?: {
+    telegramSecretToken?: string;
+  };
 }
 
 /**
@@ -127,6 +130,9 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
         accessToken: 'dev-mode-token',
         expiresAt: Math.floor(Date.now() / 1000) + 86400, // 24 hours
       },
+      requestHeaders: {
+        telegramSecretToken: req.headers['x-telegram-bot-api-secret-token'] as string | undefined,
+      },
     };
   }
 
@@ -142,6 +148,9 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
       prisma,
       user: null,
       session: null,
+      requestHeaders: {
+        telegramSecretToken: req.headers['x-telegram-bot-api-secret-token'] as string | undefined,
+      },
     };
   }
 
@@ -152,6 +161,9 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
       prisma,
       user: null,
       session: null,
+      requestHeaders: {
+        telegramSecretToken: req.headers['x-telegram-bot-api-secret-token'] as string | undefined,
+      },
     };
   }
 
@@ -231,6 +243,9 @@ export async function createContext({ req }: CreateExpressContextOptions): Promi
       prisma,
       user: null,
       session: null,
+      requestHeaders: {
+        telegramSecretToken: req.headers['x-telegram-bot-api-secret-token'] as string | undefined,
+      },
     };
   }
 }

--- a/backend/src/api/trpc/routers/__tests__/feedback.test.ts
+++ b/backend/src/api/trpc/routers/__tests__/feedback.test.ts
@@ -551,10 +551,14 @@ describe('feedback.getAll', () => {
 // ===========================================================================
 
 describe('feedback.getById', () => {
-  it('legacy UUID is resolved via feedbackResponse.findUnique', async () => {
+  it('manager can read in-scope legacy UUID', async () => {
+    store.state.userManagers.push({ managerId: 'mgr-1', accountantId: 'acc-1' });
+    store.state.chats.push({ id: 100n, assignedAccountantId: 'acc-1', deletedAt: null });
+
     const legacyId = seedLegacy({
       rating: 5,
       submittedAt: new Date('2025-03-01'),
+      chatId: 100n,
       chatTitle: 'Acme',
       accountantName: 'Alice',
       clientUsername: 'client-a',
@@ -569,10 +573,29 @@ describe('feedback.getById', () => {
     expect(result.rating).toBe(5);
   });
 
-  it('vote UUID is resolved via surveyVote.findUnique fallback', async () => {
+  it('manager gets FORBIDDEN for out-of-scope legacy UUID', async () => {
+    store.state.userManagers.push({ managerId: 'mgr-1', accountantId: 'acc-1' });
+    store.state.chats.push({ id: 100n, assignedAccountantId: 'acc-1', deletedAt: null });
+
+    const legacyId = seedLegacy({
+      rating: 4,
+      submittedAt: new Date('2025-03-01'),
+      chatId: 200n,
+      chatTitle: 'Other Tenant',
+    });
+
+    const caller = makeCaller({ id: 'mgr-1', role: 'manager' });
+    await expect(caller.getById({ id: legacyId })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('manager can read in-scope vote UUID via fallback', async () => {
+    store.state.userManagers.push({ managerId: 'mgr-1', accountantId: 'acc-1' });
+    store.state.chats.push({ id: 100n, assignedAccountantId: 'acc-1', deletedAt: null });
+
     const voteId = seedVote({
       rating: 3,
       updatedAt: new Date('2026-04-15'),
+      chatId: 100n,
       username: 'vote-user',
       accountantName: 'Bob',
       chatTitle: 'Vote Corp',
@@ -585,6 +608,36 @@ describe('feedback.getById', () => {
     expect(result.clientUsername).toBe('vote-user');
     expect(result.chatTitle).toBe('Vote Corp');
     expect(result.accountant?.fullName).toBe('Bob');
+  });
+
+  it('manager gets FORBIDDEN for out-of-scope vote UUID', async () => {
+    store.state.userManagers.push({ managerId: 'mgr-1', accountantId: 'acc-1' });
+    store.state.chats.push({ id: 100n, assignedAccountantId: 'acc-1', deletedAt: null });
+
+    const voteId = seedVote({
+      rating: 2,
+      updatedAt: new Date('2026-04-15'),
+      chatId: 200n,
+      username: 'outside-user',
+    });
+
+    const caller = makeCaller({ id: 'mgr-1', role: 'manager' });
+    await expect(caller.getById({ id: voteId })).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('admin can read legacy UUID without scope restrictions', async () => {
+    const legacyId = seedLegacy({
+      rating: 5,
+      submittedAt: new Date('2025-03-01'),
+      chatId: 999n,
+      chatTitle: 'Admin Visible',
+    });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.getById({ id: legacyId });
+
+    expect(result.id).toBe(legacyId);
+    expect(result.rating).toBe(5);
   });
 
   it('throws NOT_FOUND when UUID exists in neither table', async () => {

--- a/backend/src/api/trpc/routers/__tests__/feedback.test.ts
+++ b/backend/src/api/trpc/routers/__tests__/feedback.test.ts
@@ -259,10 +259,15 @@ import logger from '../../../../utils/logger.js';
 
 type Role = 'admin' | 'manager' | 'observer' | 'accountant';
 
-function makeCaller(user: {
-  id: string;
-  role: Role;
-}): ReturnType<typeof feedbackRouter.createCaller> {
+function makeCaller(
+  user: {
+    id: string;
+    role: Role;
+  },
+  opts?: {
+    telegramSecretToken?: string;
+  }
+): ReturnType<typeof feedbackRouter.createCaller> {
   return feedbackRouter.createCaller({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mocked Prisma surface
     prisma: mockPrisma as any,
@@ -276,6 +281,9 @@ function makeCaller(user: {
     session: {
       accessToken: 'test',
       expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    },
+    requestHeaders: {
+      telegramSecretToken: opts?.telegramSecretToken,
     },
   });
 }
@@ -385,6 +393,7 @@ beforeEach(() => {
   store.state.reset();
   seq = 0;
   vi.clearAllMocks();
+  process.env['TELEGRAM_WEBHOOK_SECRET'] = 'test-webhook-secret-token-1234567890';
 });
 
 // ===========================================================================
@@ -730,8 +739,11 @@ describe('feedback.getAggregates', () => {
 // ===========================================================================
 
 describe('feedback.submitRating (deprecated)', () => {
-  it('still processes the request but logs a deprecation warning', async () => {
-    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+  it('still processes the request with valid bot signature and logs deprecation warning', async () => {
+    const caller = makeCaller(
+      { id: 'admin-1', role: 'admin' },
+      { telegramSecretToken: process.env['TELEGRAM_WEBHOOK_SECRET'] }
+    );
     const result = await caller.submitRating({
       deliveryId: '00000000-0000-4000-a000-000000000001',
       rating: 5,
@@ -743,5 +755,89 @@ describe('feedback.submitRating (deprecated)', () => {
       expect.stringContaining('[deprecated]'),
       expect.objectContaining({ adr: 'ADR-007' })
     );
+  });
+
+  it('rejects submitRating without bot signature', async () => {
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+
+    await expect(
+      caller.submitRating({
+        deliveryId: '00000000-0000-4000-a000-000000000001',
+        rating: 5,
+        telegramUsername: 'x',
+      })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('rejects submitRating with invalid bot signature', async () => {
+    const caller = makeCaller(
+      { id: 'admin-1', role: 'admin' },
+      { telegramSecretToken: 'invalid-secret' }
+    );
+
+    await expect(
+      caller.submitRating({
+        deliveryId: '00000000-0000-4000-a000-000000000001',
+        rating: 5,
+        telegramUsername: 'x',
+      })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('allows addComment with valid bot signature', async () => {
+    const feedbackId = seedLegacy({
+      rating: 4,
+      submittedAt: new Date('2025-03-01'),
+      comment: null,
+    });
+
+    const caller = makeCaller(
+      { id: 'admin-1', role: 'admin' },
+      { telegramSecretToken: process.env['TELEGRAM_WEBHOOK_SECRET'] }
+    );
+
+    const result = await caller.addComment({
+      feedbackId,
+      comment: 'Thanks for the service',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects addComment without bot signature', async () => {
+    const feedbackId = seedLegacy({
+      rating: 4,
+      submittedAt: new Date('2025-03-01'),
+      comment: null,
+    });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+
+    await expect(
+      caller.addComment({
+        feedbackId,
+        comment: 'Should be blocked',
+      })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('rejects addComment with invalid bot signature', async () => {
+    const feedbackId = seedLegacy({
+      rating: 4,
+      submittedAt: new Date('2025-03-01'),
+      comment: null,
+    });
+
+    const caller = makeCaller(
+      { id: 'admin-1', role: 'admin' },
+      { telegramSecretToken: 'invalid-secret' }
+    );
+
+    await expect(
+      caller.addComment({
+        feedbackId,
+        comment: 'Should be blocked',
+      })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 });

--- a/backend/src/api/trpc/routers/__tests__/feedback.test.ts
+++ b/backend/src/api/trpc/routers/__tests__/feedback.test.ts
@@ -255,7 +255,6 @@ vi.mock('../../../../services/feedback/survey.service.js', () => ({
 
 // Import AFTER mocks.
 import { feedbackRouter } from '../feedback.js';
-import { createContext } from '../../context.js';
 import logger from '../../../../utils/logger.js';
 
 type Role = 'admin' | 'manager' | 'observer' | 'accountant';
@@ -840,31 +839,5 @@ describe('feedback.submitRating (deprecated)', () => {
         comment: 'Should be blocked',
       })
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
-  });
-
-  it('createContext propagates telegram secret header for botProcedure auth', async () => {
-    const secret = 'integration-test-webhook-secret-1234567890';
-    process.env['TELEGRAM_WEBHOOK_SECRET'] = secret;
-
-    const feedbackId = seedLegacy({
-      rating: 5,
-      submittedAt: new Date('2025-03-01'),
-      comment: null,
-    });
-
-    const req = {
-      headers: {
-        'x-telegram-bot-api-secret-token': secret,
-      },
-    };
-    const ctx = await createContext({ req } as never);
-    const caller = feedbackRouter.createCaller(ctx);
-
-    const result = await caller.addComment({
-      feedbackId,
-      comment: 'Context propagated signature',
-    });
-
-    expect(result.success).toBe(true);
   });
 });

--- a/backend/src/api/trpc/routers/__tests__/feedback.test.ts
+++ b/backend/src/api/trpc/routers/__tests__/feedback.test.ts
@@ -255,6 +255,7 @@ vi.mock('../../../../services/feedback/survey.service.js', () => ({
 
 // Import AFTER mocks.
 import { feedbackRouter } from '../feedback.js';
+import { createContext } from '../../context.js';
 import logger from '../../../../utils/logger.js';
 
 type Role = 'admin' | 'manager' | 'observer' | 'accountant';
@@ -839,5 +840,31 @@ describe('feedback.submitRating (deprecated)', () => {
         comment: 'Should be blocked',
       })
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('createContext propagates telegram secret header for botProcedure auth', async () => {
+    const secret = 'integration-test-webhook-secret-1234567890';
+    process.env['TELEGRAM_WEBHOOK_SECRET'] = secret;
+
+    const feedbackId = seedLegacy({
+      rating: 5,
+      submittedAt: new Date('2025-03-01'),
+      comment: null,
+    });
+
+    const req = {
+      headers: {
+        'x-telegram-bot-api-secret-token': secret,
+      },
+    };
+    const ctx = await createContext({ req } as never);
+    const caller = feedbackRouter.createCaller(ctx);
+
+    const result = await caller.addComment({
+      feedbackId,
+      comment: 'Context propagated signature',
+    });
+
+    expect(result.success).toBe(true);
   });
 });

--- a/backend/src/api/trpc/routers/__tests__/feedback.test.ts
+++ b/backend/src/api/trpc/routers/__tests__/feedback.test.ts
@@ -1,0 +1,694 @@
+/**
+ * Feedback Router Tests (gh-324 / ADR-007)
+ *
+ * Regression coverage for the unified read model. The router is invoked via
+ * `createCaller` against a mocked Prisma client; the same in-memory store
+ * powers both router endpoints and the analytics helpers they call.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Shared store (hoisted so vi.mock factories can read it).
+// ---------------------------------------------------------------------------
+const store = vi.hoisted(() => {
+  type LegacyRow = {
+    id: string;
+    chatId: bigint;
+    rating: number;
+    comment: string | null;
+    submittedAt: Date;
+    clientUsername: string | null;
+    surveyId: string | null;
+    requestId: string | null;
+    deliveryId: string | null;
+    chat: {
+      title: string | null;
+      assignedAccountant: {
+        id: string;
+        fullName: string;
+        email: string;
+      } | null;
+    } | null;
+    survey: { id: string; quarter: string | null; status: string } | null;
+  };
+
+  type VoteRow = {
+    id: string;
+    deliveryId: string;
+    telegramUserId: bigint;
+    username: string | null;
+    rating: number;
+    comment: string | null;
+    state: 'active' | 'removed';
+    createdAt: Date;
+    updatedAt: Date;
+    delivery: {
+      chatId: bigint;
+      surveyId: string;
+      chat: {
+        title: string | null;
+        assignedAccountant: {
+          id: string;
+          fullName: string;
+          email: string;
+        } | null;
+      } | null;
+      survey: { id: string; quarter: string | null; status: string } | null;
+    };
+  };
+
+  const state = {
+    legacy: [] as LegacyRow[],
+    votes: [] as VoteRow[],
+    // Scoping helpers query these tables:
+    userManagers: [] as { managerId: string; accountantId: string }[],
+    chats: [] as { id: bigint; assignedAccountantId: string | null; deletedAt: Date | null }[],
+    reset(): void {
+      state.legacy = [];
+      state.votes = [];
+      state.userManagers = [];
+      state.chats = [];
+    },
+  };
+
+  return { state };
+});
+
+type DateFilter = { gte?: Date; lte?: Date } | undefined;
+
+function matchesDate(value: Date, filter: DateFilter): boolean {
+  if (!filter) return true;
+  if (filter.gte && value < filter.gte) return false;
+  if (filter.lte && value > filter.lte) return false;
+  return true;
+}
+
+function matchesCommentNotNull(filter: { not: null } | undefined, value: string | null): boolean {
+  if (!filter) return true;
+  return value !== null;
+}
+
+function matchesInBigInt(filter: { in: bigint[] } | undefined, value: bigint): boolean {
+  if (!filter) return true;
+  return filter.in.includes(value);
+}
+
+function matchesRatingFilter(
+  filter: { gte?: number; lte?: number } | undefined,
+  rating: number
+): boolean {
+  if (!filter) return true;
+  if (filter.gte !== undefined && rating < filter.gte) return false;
+  if (filter.lte !== undefined && rating > filter.lte) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Prisma mock
+// ---------------------------------------------------------------------------
+const mockPrisma = vi.hoisted(() => {
+  function legacyFindMany(args: {
+    where?: Record<string, unknown>;
+    orderBy?: { submittedAt?: 'asc' | 'desc' };
+    take?: number;
+  }): unknown[] {
+    const where = args.where ?? {};
+    let rows = store.state.legacy.filter((r) => {
+      if (!matchesDate(r.submittedAt, (where as { submittedAt?: DateFilter }).submittedAt))
+        return false;
+      const cw = where as { comment?: { not: null } };
+      if (!matchesCommentNotNull(cw.comment, r.comment)) return false;
+      const sid = (where as { surveyId?: string }).surveyId;
+      if (sid !== undefined && r.surveyId !== sid) return false;
+      const cidFilter = (where as { chatId?: bigint | { in: bigint[] } }).chatId;
+      if (typeof cidFilter === 'bigint') {
+        if (r.chatId !== cidFilter) return false;
+      } else if (!matchesInBigInt(cidFilter, r.chatId)) return false;
+      const rf = (where as { rating?: { gte?: number; lte?: number } }).rating;
+      if (!matchesRatingFilter(rf, r.rating)) return false;
+      return true;
+    });
+    if (args.orderBy?.submittedAt === 'desc') {
+      rows = [...rows].sort((a, b) => b.submittedAt.getTime() - a.submittedAt.getTime());
+    }
+    if (args.take !== undefined) rows = rows.slice(0, args.take);
+    return rows;
+  }
+
+  function voteFindMany(args: {
+    where?: Record<string, unknown>;
+    orderBy?: { updatedAt?: 'asc' | 'desc' };
+    take?: number;
+  }): unknown[] {
+    const where = args.where ?? {};
+    let rows = store.state.votes.filter((v) => {
+      const stateFilter = (where as { state?: 'active' | 'removed' }).state;
+      if (stateFilter !== undefined && v.state !== stateFilter) return false;
+      if (!matchesDate(v.updatedAt, (where as { updatedAt?: DateFilter }).updatedAt)) return false;
+      const cw = where as { comment?: { not: null } };
+      if (!matchesCommentNotNull(cw.comment, v.comment)) return false;
+      const delivery = (
+        where as {
+          delivery?: {
+            surveyId?: string;
+            chatId?: bigint | { in: bigint[] };
+          };
+        }
+      ).delivery;
+      if (delivery) {
+        if (delivery.surveyId !== undefined && v.delivery.surveyId !== delivery.surveyId)
+          return false;
+        const cidFilter = delivery.chatId;
+        if (typeof cidFilter === 'bigint') {
+          if (v.delivery.chatId !== cidFilter) return false;
+        } else if (!matchesInBigInt(cidFilter, v.delivery.chatId)) return false;
+      }
+      const rf = (where as { rating?: { gte?: number; lte?: number } }).rating;
+      if (!matchesRatingFilter(rf, v.rating)) return false;
+      return true;
+    });
+    if (args.orderBy?.updatedAt === 'desc') {
+      rows = [...rows].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+    }
+    if (args.take !== undefined) rows = rows.slice(0, args.take);
+    return rows;
+  }
+
+  return {
+    feedbackResponse: {
+      findMany: vi.fn(legacyFindMany),
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) => {
+        return store.state.legacy.find((r) => r.id === where.id) ?? null;
+      }),
+      count: vi.fn(
+        (args: { where?: Record<string, unknown> }) => legacyFindMany({ where: args.where }).length
+      ),
+      update: vi.fn(async () => ({})),
+    },
+    surveyVote: {
+      findMany: vi.fn(voteFindMany),
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) => {
+        return store.state.votes.find((v) => v.id === where.id) ?? null;
+      }),
+    },
+    clientRequest: {
+      findFirst: vi.fn(async () => null),
+    },
+    userManager: {
+      findMany: vi.fn(async ({ where }: { where: { managerId: string } }) =>
+        store.state.userManagers.filter((r) => r.managerId === where.managerId)
+      ),
+    },
+    chat: {
+      findMany: vi.fn(
+        async ({
+          where,
+        }: {
+          where: { assignedAccountantId?: string | { in: string[] }; deletedAt?: null };
+        }) => {
+          void where.deletedAt;
+          const idFilter = where.assignedAccountantId;
+          let rows = store.state.chats;
+          if (typeof idFilter === 'string') {
+            rows = rows.filter((c) => c.assignedAccountantId === idFilter);
+          } else if (idFilter && 'in' in idFilter) {
+            rows = rows.filter(
+              (c) => c.assignedAccountantId && idFilter.in.includes(c.assignedAccountantId)
+            );
+          }
+          return rows.map((c) => ({ id: c.id }));
+        }
+      ),
+    },
+  };
+});
+
+vi.mock('../../../../lib/prisma.js', () => ({
+  prisma: mockPrisma,
+}));
+
+vi.mock('../../../../utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Queue module — not exercised here, but import-time resolution must succeed.
+vi.mock('../../../../queues/setup.js', () => ({
+  queueLowRatingAlert: vi.fn(async () => undefined),
+}));
+
+// Survey-service functions used only by submitRating.
+vi.mock('../../../../services/feedback/survey.service.js', () => ({
+  recordResponse: vi.fn(async () => 'fake-feedback-id'),
+  getDeliveryById: vi.fn(async () => ({
+    id: 'fake-delivery-id',
+    chatId: 99n,
+    status: 'delivered',
+    survey: { status: 'active' },
+  })),
+}));
+
+// Import AFTER mocks.
+import { feedbackRouter } from '../feedback.js';
+import logger from '../../../../utils/logger.js';
+
+type Role = 'admin' | 'manager' | 'observer' | 'accountant';
+
+function makeCaller(user: {
+  id: string;
+  role: Role;
+}): ReturnType<typeof feedbackRouter.createCaller> {
+  return feedbackRouter.createCaller({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- mocked Prisma surface
+    prisma: mockPrisma as any,
+    user: {
+      id: user.id,
+      email: `${user.id}@test.local`,
+      fullName: 'Test User',
+      role: user.role,
+      isActive: true,
+    },
+    session: {
+      accessToken: 'test',
+      expiresAt: Math.floor(Date.now() / 1000) + 3600,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Seed helpers
+// ---------------------------------------------------------------------------
+
+let seq = 0;
+// Build a valid RFC 4122 v4 UUID where only the last segment varies. Zod's
+// `.uuid()` refines are strict, so we can't use an ad-hoc prefix.
+const uuid = (_prefix: string): string => {
+  seq++;
+  const tail = seq.toString(16).padStart(12, '0');
+  return `00000000-0000-4000-a000-${tail}`;
+};
+
+function seedLegacy(attrs: {
+  rating: number;
+  submittedAt: Date;
+  chatId?: bigint;
+  surveyId?: string | null;
+  comment?: string | null;
+  clientUsername?: string | null;
+  chatTitle?: string | null;
+  accountantName?: string | null;
+  quarter?: string | null;
+}): string {
+  const id = uuid('fr');
+  store.state.legacy.push({
+    id,
+    chatId: attrs.chatId ?? 1000n,
+    rating: attrs.rating,
+    comment: attrs.comment ?? null,
+    submittedAt: attrs.submittedAt,
+    clientUsername: attrs.clientUsername ?? null,
+    surveyId: attrs.surveyId ?? null,
+    requestId: null,
+    deliveryId: null,
+    chat: {
+      title: attrs.chatTitle ?? 'Legacy Chat',
+      assignedAccountant: attrs.accountantName
+        ? {
+            id: 'acc-legacy',
+            fullName: attrs.accountantName,
+            email: 'acc@legacy.test',
+          }
+        : null,
+    },
+    survey: attrs.surveyId
+      ? { id: attrs.surveyId, quarter: attrs.quarter ?? '2025-Q1', status: 'closed' }
+      : null,
+  });
+  return id;
+}
+
+function seedVote(attrs: {
+  rating: number;
+  updatedAt: Date;
+  createdAt?: Date;
+  chatId?: bigint;
+  surveyId?: string;
+  comment?: string | null;
+  username?: string | null;
+  telegramUserId?: bigint;
+  state?: 'active' | 'removed';
+  quarter?: string | null;
+  deliveryId?: string;
+  chatTitle?: string | null;
+  accountantName?: string | null;
+}): string {
+  const id = uuid('sv');
+  store.state.votes.push({
+    id,
+    deliveryId: attrs.deliveryId ?? uuid('del'),
+    telegramUserId: attrs.telegramUserId ?? 1n,
+    username: attrs.username ?? null,
+    rating: attrs.rating,
+    comment: attrs.comment ?? null,
+    state: attrs.state ?? 'active',
+    createdAt: attrs.createdAt ?? attrs.updatedAt,
+    updatedAt: attrs.updatedAt,
+    delivery: {
+      chatId: attrs.chatId ?? 2000n,
+      surveyId: attrs.surveyId ?? uuid('sur'),
+      chat: {
+        title: attrs.chatTitle ?? 'Vote Chat',
+        assignedAccountant: attrs.accountantName
+          ? {
+              id: 'acc-vote',
+              fullName: attrs.accountantName,
+              email: 'acc@vote.test',
+            }
+          : null,
+      },
+      survey: {
+        id: attrs.surveyId ?? 'sur-1',
+        quarter: attrs.quarter ?? '2026-Q1',
+        status: 'active',
+      },
+    },
+  });
+  return id;
+}
+
+beforeEach(() => {
+  store.state.reset();
+  seq = 0;
+  vi.clearAllMocks();
+});
+
+// ===========================================================================
+// getAll
+// ===========================================================================
+
+describe('feedback.getAll', () => {
+  it('legacy-only: returns rows from feedbackResponse', async () => {
+    seedLegacy({ rating: 5, submittedAt: new Date('2025-03-01') });
+    seedLegacy({ rating: 4, submittedAt: new Date('2025-03-02') });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.getAll();
+
+    expect(result.pagination.totalItems).toBe(2);
+    expect(result.items).toHaveLength(2);
+    // DESC sort.
+    expect(result.items[0].rating).toBe(4);
+    expect(result.items[1].rating).toBe(5);
+  });
+
+  it('vote-only: returns rows from surveyVote when legacy is empty', async () => {
+    seedVote({
+      rating: 4,
+      updatedAt: new Date('2026-04-10'),
+      username: 'alice',
+    });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.getAll();
+
+    expect(result.pagination.totalItems).toBe(1);
+    expect(result.items[0].clientUsername).toBe('alice');
+    expect(result.items[0].rating).toBe(4);
+  });
+
+  it('mixed: merges and sorts DESC by submittedAt', async () => {
+    seedLegacy({ rating: 5, submittedAt: new Date('2025-03-01') });
+    seedVote({ rating: 3, updatedAt: new Date('2026-04-01') });
+    seedLegacy({ rating: 4, submittedAt: new Date('2025-05-01') });
+    seedVote({ rating: 2, updatedAt: new Date('2026-02-01') });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.getAll();
+
+    expect(result.pagination.totalItems).toBe(4);
+    const ratings = result.items.map((i) => i.rating);
+    // 2026-04 → 2026-02 → 2025-05 → 2025-03
+    expect(ratings).toEqual([3, 2, 4, 5]);
+  });
+
+  it('multi-user per delivery: N entries in the listing', async () => {
+    const delId = uuid('del');
+    const surveyId = uuid('sur');
+    seedVote({
+      rating: 5,
+      updatedAt: new Date('2026-04-10'),
+      deliveryId: delId,
+      telegramUserId: 1n,
+      username: 'u1',
+      surveyId,
+    });
+    seedVote({
+      rating: 3,
+      updatedAt: new Date('2026-04-11'),
+      deliveryId: delId,
+      telegramUserId: 2n,
+      username: 'u2',
+      surveyId,
+    });
+    seedVote({
+      rating: 4,
+      updatedAt: new Date('2026-04-12'),
+      deliveryId: delId,
+      telegramUserId: 3n,
+      username: 'u3',
+      surveyId,
+    });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.getAll();
+
+    expect(result.pagination.totalItems).toBe(3);
+    expect(result.items.map((i) => i.clientUsername)).toEqual(['u3', 'u2', 'u1']);
+  });
+
+  it('rating bounds filter applies across both sources', async () => {
+    seedLegacy({ rating: 1, submittedAt: new Date('2025-03-01') });
+    seedLegacy({ rating: 5, submittedAt: new Date('2025-03-02') });
+    seedVote({ rating: 2, updatedAt: new Date('2026-04-01') });
+    seedVote({ rating: 4, updatedAt: new Date('2026-04-02') });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.getAll({
+      minRating: 2,
+      maxRating: 4,
+      page: 1,
+      pageSize: 20,
+    });
+
+    expect(result.items.map((i) => i.rating).sort()).toEqual([2, 4]);
+  });
+
+  it('scoping restricts to assigned chats (manager role)', async () => {
+    // Seed chat mapping: manager -> accountant acc-1; acc-1 assigned to chat 100.
+    store.state.userManagers.push({ managerId: 'mgr-1', accountantId: 'acc-1' });
+    store.state.chats.push({
+      id: 100n,
+      assignedAccountantId: 'acc-1',
+      deletedAt: null,
+    });
+
+    seedLegacy({ rating: 5, submittedAt: new Date('2025-03-01'), chatId: 100n });
+    seedLegacy({ rating: 4, submittedAt: new Date('2025-03-02'), chatId: 200n }); // out of scope
+    seedVote({ rating: 3, updatedAt: new Date('2026-04-01'), chatId: 100n });
+    seedVote({ rating: 2, updatedAt: new Date('2026-04-02'), chatId: 300n }); // out of scope
+
+    const caller = makeCaller({ id: 'mgr-1', role: 'manager' });
+    const result = await caller.getAll();
+
+    expect(result.pagination.totalItems).toBe(2);
+    expect(result.items.map((i) => i.rating).sort()).toEqual([3, 5]);
+  });
+
+  it('numeric chatId filter is applied to both sources', async () => {
+    seedLegacy({ rating: 5, submittedAt: new Date('2025-03-01'), chatId: 100n });
+    seedLegacy({ rating: 4, submittedAt: new Date('2025-03-02'), chatId: 200n });
+    seedVote({ rating: 3, updatedAt: new Date('2026-04-01'), chatId: 100n });
+    seedVote({ rating: 2, updatedAt: new Date('2026-04-02'), chatId: 300n });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.getAll({ chatId: '100', page: 1, pageSize: 20 });
+
+    expect(result.items).toHaveLength(2);
+    expect(result.items.every((i) => i.chatId === '100')).toBe(true);
+  });
+
+  it('rejects non-numeric chatId with BAD_REQUEST', async () => {
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    await expect(
+      caller.getAll({ chatId: 'not-a-number', page: 1, pageSize: 20 })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('DTO shape: chatId is a string, submittedAt is a Date', async () => {
+    seedVote({
+      rating: 5,
+      updatedAt: new Date('2026-04-10'),
+      chatId: 42n,
+      username: 'x',
+    });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.getAll();
+
+    expect(typeof result.items[0].chatId).toBe('string');
+    expect(result.items[0].chatId).toBe('42');
+    expect(result.items[0].submittedAt).toBeInstanceOf(Date);
+  });
+});
+
+// ===========================================================================
+// getById
+// ===========================================================================
+
+describe('feedback.getById', () => {
+  it('legacy UUID is resolved via feedbackResponse.findUnique', async () => {
+    const legacyId = seedLegacy({
+      rating: 5,
+      submittedAt: new Date('2025-03-01'),
+      chatTitle: 'Acme',
+      accountantName: 'Alice',
+      clientUsername: 'client-a',
+      surveyId: 'sur-legacy',
+    });
+
+    const caller = makeCaller({ id: 'mgr-1', role: 'manager' });
+    const result = await caller.getById({ id: legacyId });
+
+    expect(result.id).toBe(legacyId);
+    expect(result.chatTitle).toBe('Acme');
+    expect(result.rating).toBe(5);
+  });
+
+  it('vote UUID is resolved via surveyVote.findUnique fallback', async () => {
+    const voteId = seedVote({
+      rating: 3,
+      updatedAt: new Date('2026-04-15'),
+      username: 'vote-user',
+      accountantName: 'Bob',
+      chatTitle: 'Vote Corp',
+    });
+
+    const caller = makeCaller({ id: 'mgr-1', role: 'manager' });
+    const result = await caller.getById({ id: voteId });
+
+    expect(result.id).toBe(voteId);
+    expect(result.clientUsername).toBe('vote-user');
+    expect(result.chatTitle).toBe('Vote Corp');
+    expect(result.accountant?.fullName).toBe('Bob');
+  });
+
+  it('throws NOT_FOUND when UUID exists in neither table', async () => {
+    const caller = makeCaller({ id: 'mgr-1', role: 'manager' });
+    await expect(
+      caller.getById({ id: '00000000-0000-4000-a000-000000000000' })
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+});
+
+// ===========================================================================
+// exportCsv
+// ===========================================================================
+
+describe('feedback.exportCsv', () => {
+  it('includes both legacy and vote rows with proper escaping', async () => {
+    seedLegacy({
+      rating: 5,
+      submittedAt: new Date('2025-03-01T10:00:00Z'),
+      comment: 'good, legacy',
+      chatTitle: 'Client A',
+      clientUsername: 'client-a',
+    });
+    seedVote({
+      rating: 4,
+      updatedAt: new Date('2026-04-10T10:00:00Z'),
+      comment: 'vote-comment',
+      chatTitle: 'Client B',
+      username: 'client-b',
+    });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.exportCsv();
+
+    const lines = result.content.split('\n');
+    expect(lines[0]).toContain('Rating');
+    // Header + 2 data rows.
+    expect(lines).toHaveLength(3);
+    // Vote row is newer → appears first.
+    expect(lines[1]).toContain('client-b');
+    expect(lines[2]).toContain('client-a');
+    // "good, legacy" must be quoted because it contains a comma.
+    expect(result.content).toContain('"good, legacy"');
+    expect(result.rowCount).toBe(2);
+  });
+});
+
+// ===========================================================================
+// getAggregates (scoped vs unrestricted)
+// ===========================================================================
+
+describe('feedback.getAggregates', () => {
+  it('unrestricted (admin): unions aggregates across both sources', async () => {
+    seedLegacy({ rating: 5, submittedAt: new Date('2025-03-01') });
+    seedLegacy({ rating: 4, submittedAt: new Date('2025-03-02') });
+    seedVote({ rating: 3, updatedAt: new Date('2026-04-01') });
+    seedVote({ rating: 2, updatedAt: new Date('2026-04-02') });
+
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.getAggregates();
+
+    expect(result.totalResponses).toBe(4);
+    expect(result.averageRating).toBe(3.5);
+  });
+
+  it('scoped (manager): unions only for assigned chats', async () => {
+    store.state.userManagers.push({ managerId: 'mgr-1', accountantId: 'acc-1' });
+    store.state.chats.push({
+      id: 100n,
+      assignedAccountantId: 'acc-1',
+      deletedAt: null,
+    });
+
+    seedLegacy({ rating: 5, submittedAt: new Date('2025-03-01'), chatId: 100n });
+    seedVote({ rating: 4, updatedAt: new Date('2026-04-01'), chatId: 100n });
+    // out of scope:
+    seedLegacy({ rating: 1, submittedAt: new Date('2025-03-02'), chatId: 200n });
+    seedVote({ rating: 1, updatedAt: new Date('2026-04-02'), chatId: 300n });
+
+    const caller = makeCaller({ id: 'mgr-1', role: 'manager' });
+    const result = await caller.getAggregates();
+
+    expect(result.totalResponses).toBe(2);
+    expect(result.averageRating).toBe(4.5);
+  });
+});
+
+// ===========================================================================
+// submitRating — deprecation
+// ===========================================================================
+
+describe('feedback.submitRating (deprecated)', () => {
+  it('still processes the request but logs a deprecation warning', async () => {
+    const caller = makeCaller({ id: 'admin-1', role: 'admin' });
+    const result = await caller.submitRating({
+      deliveryId: '00000000-0000-4000-a000-000000000001',
+      rating: 5,
+      telegramUsername: 'x',
+    });
+
+    expect(result.success).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('[deprecated]'),
+      expect.objectContaining({ adr: 'ADR-007' })
+    );
+  });
+});

--- a/backend/src/api/trpc/routers/feedback.ts
+++ b/backend/src/api/trpc/routers/feedback.ts
@@ -398,7 +398,9 @@ export const feedbackRouter = router({
         id: z.string().uuid(),
       })
     )
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
+      const scopedChatIds = await getScopedChatIds(ctx.prisma, ctx.user.id, ctx.user.role);
+
       // 1. Legacy path.
       const feedback = await prisma.feedbackResponse.findUnique({
         where: { id: input.id },
@@ -425,6 +427,13 @@ export const feedbackRouter = router({
       });
 
       if (feedback) {
+        if (scopedChatIds && !scopedChatIds.includes(feedback.chatId)) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Not authorized to access this feedback entry',
+          });
+        }
+
         const relatedRequest = await prisma.clientRequest.findFirst({
           where: {
             chatId: feedback.chatId,
@@ -485,6 +494,13 @@ export const feedbackRouter = router({
         throw new TRPCError({
           code: 'NOT_FOUND',
           message: 'Feedback not found',
+        });
+      }
+
+      if (scopedChatIds && !scopedChatIds.includes(vote.delivery.chatId)) {
+        throw new TRPCError({
+          code: 'FORBIDDEN',
+          message: 'Not authorized to access this feedback entry',
         });
       }
 

--- a/backend/src/api/trpc/routers/feedback.ts
+++ b/backend/src/api/trpc/routers/feedback.ts
@@ -5,9 +5,12 @@
  * - getAggregates: Get aggregate feedback statistics (all roles)
  * - getAll: Get full feedback details (manager only)
  * - getById: Get single feedback entry (manager only)
- * - submitRating: Record client rating from Telegram callback
+ * - submitRating: Record client rating from Telegram callback (DEPRECATED — ADR-007)
  * - addComment: Add comment to existing feedback
  * - exportCsv: Export feedback data as CSV (manager only)
+ *
+ * Read-path is unified across `feedbackResponse` (legacy) and
+ * `surveyVote (state='active')` (canonical post-gh-294). See ADR-007.
  *
  * Role-Based Access Control (RBAC):
  * ┌─────────────────────┬───────────┬─────────┬──────────┐
@@ -33,13 +36,15 @@
 import { router, publicProcedure, managerProcedure, staffProcedure } from '../trpc.js';
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
-import type { Prisma } from '@prisma/client';
 import {
   getAggregates,
   getRecentComments,
   getTrendData,
   calculateNPS,
   calculateDistribution,
+  fetchUnifiedRatings,
+  fetchUnifiedEntries,
+  fetchUnifiedComments,
 } from '../../../services/feedback/analytics.service.js';
 import { getScopedChatIds } from '../helpers/scoping.js';
 import { recordResponse, getDeliveryById } from '../../../services/feedback/survey.service.js';
@@ -52,7 +57,10 @@ import logger from '../../../utils/logger.js';
  */
 export const feedbackRouter = router({
   /**
-   * Get aggregate feedback statistics
+   * Get aggregate feedback statistics.
+   *
+   * Reads from the unified view (`feedbackResponse ∪ surveyVote(active)`).
+   * Scoping is applied to both sources via `getScopedChatIds`.
    *
    * Available to staff: admin, manager, observer (not accountant).
    * Returns anonymized data without client-identifying information.
@@ -70,10 +78,11 @@ export const feedbackRouter = router({
         .optional()
     )
     .query(async ({ ctx, input }) => {
-      // Apply role-based chat scoping
+      // Apply role-based chat scoping. `null` = unrestricted (admin).
       const scopedChatIds = await getScopedChatIds(ctx.prisma, ctx.user.id, ctx.user.role);
 
-      // If user has unrestricted access, use the existing service functions
+      // Unrestricted path uses the existing service functions unchanged so the
+      // trend-data behavior is preserved (cross-tenant quarterly buckets).
       if (scopedChatIds === null) {
         const dateRange =
           input?.dateFrom && input?.dateTo
@@ -102,27 +111,24 @@ export const feedbackRouter = router({
         };
       }
 
-      // Scoped path: query with chatId filter
-      const feedbackWhere: Prisma.FeedbackResponseWhereInput = {
-        chatId: { in: scopedChatIds },
-      };
-      if (input?.dateFrom || input?.dateTo) {
-        feedbackWhere.submittedAt = {
-          ...(input.dateFrom && { gte: input.dateFrom }),
-          ...(input.dateTo && { lte: input.dateTo }),
-        };
-      }
-      if (input?.surveyId) {
-        feedbackWhere.surveyId = input.surveyId;
-      }
+      // Scoped path: unified read restricted to the user's chats.
+      const [ratingRows, commentRows] = await Promise.all([
+        fetchUnifiedRatings({
+          dateFrom: input?.dateFrom,
+          dateTo: input?.dateTo,
+          surveyId: input?.surveyId,
+          scopedChatIds,
+        }),
+        fetchUnifiedComments({
+          dateFrom: input?.dateFrom,
+          dateTo: input?.dateTo,
+          surveyId: input?.surveyId,
+          scopedChatIds,
+          limit: 10,
+        }),
+      ]);
 
-      const responses = await ctx.prisma.feedbackResponse.findMany({
-        where: feedbackWhere,
-        select: { rating: true, comment: true, submittedAt: true },
-        orderBy: { submittedAt: 'desc' },
-      });
-
-      const ratings = responses.map((r) => r.rating);
+      const ratings = ratingRows.map((r) => r.rating);
       const totalResponses = ratings.length;
       const averageRating =
         totalResponses > 0
@@ -131,14 +137,11 @@ export const feedbackRouter = router({
       const nps = calculateNPS(ratings);
       const distribution = calculateDistribution(ratings);
 
-      const recentComments = responses
-        .filter((r) => r.comment !== null)
-        .slice(0, 10)
-        .map((r) => ({
-          comment: r.comment!,
-          rating: r.rating,
-          submittedAt: r.submittedAt,
-        }));
+      const recentComments = commentRows.map((c) => ({
+        comment: c.comment!,
+        rating: c.rating,
+        submittedAt: c.submittedAt,
+      }));
 
       // Trend data is cross-chat aggregate; return empty for scoped users
       // (per-chat trend would require significant per-quarter queries)
@@ -160,10 +163,14 @@ export const feedbackRouter = router({
     }),
 
   /**
-   * Submit rating from Telegram callback (T018)
+   * Submit rating from Telegram callback.
    *
-   * Internal procedure for bot callback handler.
-   * Records client rating and triggers low-rating alert if needed.
+   * @deprecated As of ADR-007 / gh-324 the canonical write target for survey
+   * responses is `SurveyVote` via the bot voting flow (see
+   * `bot/handlers/survey.handler.ts:submitVote`). This mutation continues to
+   * write to the legacy `feedbackResponse` table for backward compatibility
+   * with any external caller still invoking it. Do NOT use for new features.
+   * Scheduled for removal once external callers are audited.
    *
    * @authorization Public (called from bot handler)
    */
@@ -177,6 +184,13 @@ export const feedbackRouter = router({
     )
     .mutation(async ({ input }) => {
       const { deliveryId, rating, telegramUsername } = input;
+
+      logger.warn('[deprecated] feedback.submitRating called — prefer SurveyVote flow', {
+        deliveryId,
+        rating,
+        service: 'feedback-router',
+        adr: 'ADR-007',
+      });
 
       // Verify delivery exists and is valid
       const delivery = await getDeliveryById(deliveryId);
@@ -283,11 +297,15 @@ export const feedbackRouter = router({
     }),
 
   /**
-   * Get all feedback entries with full details (T023)
+   * Get all feedback entries with full details.
    *
    * Manager-only procedure for viewing feedback with client identifiers.
    * Supports filtering by date, rating, survey, and chat.
    * Returns paginated results with chat and survey details.
+   *
+   * Reads from `feedbackResponse ∪ surveyVote(active)` (ADR-007). Pagination
+   * is applied in memory after the union + merge-sort — see
+   * `fetchUnifiedEntries`. Scoping is forwarded to both sources.
    *
    * @authorization Manager only
    */
@@ -306,83 +324,51 @@ export const feedbackRouter = router({
         })
         .optional()
     )
-    .query(async ({ input }) => {
+    .query(async ({ ctx, input }) => {
       const page = input?.page ?? 1;
       const pageSize = input?.pageSize ?? 20;
-      const skip = (page - 1) * pageSize;
 
-      // Build where clause
-      const where: Prisma.FeedbackResponseWhereInput = {};
+      // Apply role-based scoping (admin: null = unrestricted).
+      const scopedChatIds = await getScopedChatIds(ctx.prisma, ctx.user.id, ctx.user.role);
 
-      if (input?.dateFrom || input?.dateTo) {
-        where.submittedAt = {};
-        if (input.dateFrom) {
-          where.submittedAt.gte = input.dateFrom;
+      // Parse `chatId` filter (string in, BigInt out). Must be numeric; reject
+      // otherwise to mirror the previous BigInt(input.chatId) behavior.
+      let chatIdFilter: bigint | undefined;
+      if (input?.chatId !== undefined) {
+        if (!/^-?\d+$/.test(input.chatId)) {
+          throw new TRPCError({
+            code: 'BAD_REQUEST',
+            message: 'chatId must be a numeric string',
+          });
         }
-        if (input.dateTo) {
-          where.submittedAt.lte = input.dateTo;
-        }
+        chatIdFilter = BigInt(input.chatId);
       }
 
-      if (input?.surveyId) {
-        where.surveyId = input.surveyId;
-      }
-
-      if (input?.minRating || input?.maxRating) {
-        where.rating = {};
-        if (input.minRating) {
-          where.rating.gte = input.minRating;
-        }
-        if (input.maxRating) {
-          where.rating.lte = input.maxRating;
-        }
-      }
-
-      if (input?.chatId) {
-        where.chatId = BigInt(input.chatId);
-      }
-
-      // Get total count for pagination
-      const totalItems = await prisma.feedbackResponse.count({ where });
-      const totalPages = Math.ceil(totalItems / pageSize);
-
-      // Get feedback entries with relations
-      const responses = await prisma.feedbackResponse.findMany({
-        where,
-        include: {
-          chat: {
-            include: {
-              assignedAccountant: {
-                select: {
-                  fullName: true,
-                },
-              },
-            },
-          },
-          survey: {
-            select: {
-              quarter: true,
-            },
-          },
-        },
-        orderBy: {
-          submittedAt: 'desc',
-        },
-        skip,
-        take: pageSize,
+      const { items: rows, total: totalItems } = await fetchUnifiedEntries({
+        dateFrom: input?.dateFrom,
+        dateTo: input?.dateTo,
+        surveyId: input?.surveyId,
+        minRating: input?.minRating,
+        maxRating: input?.maxRating,
+        chatId: chatIdFilter,
+        scopedChatIds,
+        page,
+        pageSize,
       });
 
-      const items = responses.map((r) => ({
+      const totalPages = Math.ceil(totalItems / pageSize);
+
+      const items = rows.map((r) => ({
         id: r.id,
         chatId: r.chatId.toString(),
-        chatTitle: r.chat?.title ?? null,
+        chatTitle: r.chatTitle,
         clientUsername: r.clientUsername,
-        accountantUsername: r.chat?.assignedAccountant?.fullName ?? null,
+        accountantUsername: r.accountantName,
         rating: r.rating,
         comment: r.comment,
         submittedAt: r.submittedAt,
         surveyId: r.surveyId,
-        surveyQuarter: r.survey?.quarter ?? null,
+        surveyQuarter: r.surveyQuarter,
       }));
 
       return {
@@ -397,10 +383,12 @@ export const feedbackRouter = router({
     }),
 
   /**
-   * Get single feedback entry by ID (T024)
+   * Get single feedback entry by ID.
    *
-   * Manager-only procedure for viewing full feedback details.
-   * Includes client info, accountant info, survey details, and related request.
+   * Tries the legacy `feedbackResponse` table first (the historically
+   * authoritative source for individual DTOs). If not found, falls back to
+   * `surveyVote` by UUID — required because post-gh-294 entries live in the
+   * vote table. DTO shape is identical for both sources.
    *
    * @authorization Manager only
    */
@@ -411,6 +399,7 @@ export const feedbackRouter = router({
       })
     )
     .query(async ({ input }) => {
+      // 1. Legacy path.
       const feedback = await prisma.feedbackResponse.findUnique({
         where: { id: input.id },
         include: {
@@ -435,24 +424,77 @@ export const feedbackRouter = router({
         },
       });
 
-      if (!feedback) {
+      if (feedback) {
+        const relatedRequest = await prisma.clientRequest.findFirst({
+          where: {
+            chatId: feedback.chatId,
+            receivedAt: { lte: feedback.submittedAt },
+          },
+          orderBy: { receivedAt: 'desc' },
+          select: {
+            id: true,
+            messageText: true,
+            receivedAt: true,
+          },
+        });
+
+        return {
+          id: feedback.id,
+          chatId: feedback.chatId.toString(),
+          chatTitle: feedback.chat?.title ?? null,
+          clientUsername: feedback.clientUsername,
+          accountant: feedback.chat?.assignedAccountant ?? null,
+          rating: feedback.rating,
+          comment: feedback.comment,
+          submittedAt: feedback.submittedAt,
+          survey: feedback.survey,
+          relatedRequest,
+        };
+      }
+
+      // 2. Vote fallback (post-gh-294 canonical source).
+      const vote = await prisma.surveyVote.findUnique({
+        where: { id: input.id },
+        include: {
+          delivery: {
+            include: {
+              chat: {
+                include: {
+                  assignedAccountant: {
+                    select: {
+                      id: true,
+                      fullName: true,
+                      email: true,
+                    },
+                  },
+                },
+              },
+              survey: {
+                select: {
+                  id: true,
+                  quarter: true,
+                  status: true,
+                },
+              },
+            },
+          },
+        },
+      });
+
+      if (!vote) {
         throw new TRPCError({
           code: 'NOT_FOUND',
           message: 'Feedback not found',
         });
       }
 
-      // Try to find related request (most recent before feedback submission)
+      const voteSubmittedAt = vote.updatedAt;
       const relatedRequest = await prisma.clientRequest.findFirst({
         where: {
-          chatId: feedback.chatId,
-          receivedAt: {
-            lte: feedback.submittedAt,
-          },
+          chatId: vote.delivery.chatId,
+          receivedAt: { lte: voteSubmittedAt },
         },
-        orderBy: {
-          receivedAt: 'desc',
-        },
+        orderBy: { receivedAt: 'desc' },
         select: {
           id: true,
           messageText: true,
@@ -461,24 +503,24 @@ export const feedbackRouter = router({
       });
 
       return {
-        id: feedback.id,
-        chatId: feedback.chatId.toString(),
-        chatTitle: feedback.chat?.title ?? null,
-        clientUsername: feedback.clientUsername,
-        accountant: feedback.chat?.assignedAccountant ?? null,
-        rating: feedback.rating,
-        comment: feedback.comment,
-        submittedAt: feedback.submittedAt,
-        survey: feedback.survey,
+        id: vote.id,
+        chatId: vote.delivery.chatId.toString(),
+        chatTitle: vote.delivery.chat?.title ?? null,
+        clientUsername: vote.username,
+        accountant: vote.delivery.chat?.assignedAccountant ?? null,
+        rating: vote.rating,
+        comment: vote.comment,
+        submittedAt: voteSubmittedAt,
+        survey: vote.delivery.survey,
         relatedRequest,
       };
     }),
 
   /**
-   * Export feedback data as CSV (T025)
+   * Export feedback data as CSV.
    *
-   * Manager-only procedure for exporting feedback to CSV.
-   * Includes all feedback details with optional date/survey filters.
+   * Reads from `feedbackResponse ∪ surveyVote(active)` (ADR-007). No
+   * pagination — the CSV contains the full filtered set.
    *
    * @authorization Manager only
    */
@@ -492,45 +534,15 @@ export const feedbackRouter = router({
         })
         .optional()
     )
-    .query(async ({ input }) => {
-      // Build where clause
-      const where: Prisma.FeedbackResponseWhereInput = {};
+    .query(async ({ ctx, input }) => {
+      const scopedChatIds = await getScopedChatIds(ctx.prisma, ctx.user.id, ctx.user.role);
 
-      if (input?.dateFrom || input?.dateTo) {
-        where.submittedAt = {};
-        if (input.dateFrom) {
-          where.submittedAt.gte = input.dateFrom;
-        }
-        if (input.dateTo) {
-          where.submittedAt.lte = input.dateTo;
-        }
-      }
-
-      if (input?.surveyId) {
-        where.surveyId = input.surveyId;
-      }
-
-      const responses = await prisma.feedbackResponse.findMany({
-        where,
-        include: {
-          chat: {
-            include: {
-              assignedAccountant: {
-                select: {
-                  fullName: true,
-                },
-              },
-            },
-          },
-          survey: {
-            select: {
-              quarter: true,
-            },
-          },
-        },
-        orderBy: {
-          submittedAt: 'desc',
-        },
+      const { items: rows } = await fetchUnifiedEntries({
+        dateFrom: input?.dateFrom,
+        dateTo: input?.dateTo,
+        surveyId: input?.surveyId,
+        scopedChatIds,
+        // No pagination — export all matching rows.
       });
 
       // Build CSV header
@@ -548,21 +560,21 @@ export const feedbackRouter = router({
       ];
 
       // Build CSV rows
-      const rows = responses.map((r) => [
+      const csvRows = rows.map((r) => [
         r.id,
         r.chatId.toString(),
-        escapeCSV(r.chat?.title ?? ''),
+        escapeCSV(r.chatTitle ?? ''),
         escapeCSV(r.clientUsername ?? ''),
-        escapeCSV(r.chat?.assignedAccountant?.fullName ?? ''),
+        escapeCSV(r.accountantName ?? ''),
         r.rating.toString(),
         escapeCSV(r.comment ?? ''),
         r.submittedAt.toISOString(),
         r.surveyId ?? '',
-        r.survey?.quarter ?? '',
+        r.surveyQuarter ?? '',
       ]);
 
       // Combine into CSV content
-      const content = [headers.join(','), ...rows.map((row) => row.join(','))].join('\n');
+      const content = [headers.join(','), ...csvRows.map((row) => row.join(','))].join('\n');
 
       // Generate filename with date range
       const dateStr = new Date().toISOString().split('T')[0];
@@ -571,7 +583,7 @@ export const feedbackRouter = router({
       return {
         filename,
         content,
-        rowCount: responses.length,
+        rowCount: rows.length,
       };
     }),
 });

--- a/backend/src/api/trpc/routers/feedback.ts
+++ b/backend/src/api/trpc/routers/feedback.ts
@@ -33,7 +33,7 @@
  * @module api/trpc/routers/feedback
  */
 
-import { router, publicProcedure, managerProcedure, staffProcedure } from '../trpc.js';
+import { router, botProcedure, managerProcedure, staffProcedure } from '../trpc.js';
 import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import {
@@ -174,7 +174,7 @@ export const feedbackRouter = router({
    *
    * @authorization Public (called from bot handler)
    */
-  submitRating: publicProcedure
+  submitRating: botProcedure
     .input(
       z.object({
         deliveryId: z.string().uuid(),
@@ -263,7 +263,7 @@ export const feedbackRouter = router({
    *
    * @authorization Public (called from bot handler)
    */
-  addComment: publicProcedure
+  addComment: botProcedure
     .input(
       z.object({
         feedbackId: z.string().uuid(),

--- a/backend/src/api/trpc/routers/feedback.ts
+++ b/backend/src/api/trpc/routers/feedback.ts
@@ -172,7 +172,7 @@ export const feedbackRouter = router({
    * with any external caller still invoking it. Do NOT use for new features.
    * Scheduled for removal once external callers are audited.
    *
-   * @authorization Public (called from bot handler)
+   * @authorization Bot webhook only (requires valid Telegram secret header)
    */
   submitRating: botProcedure
     .input(
@@ -261,7 +261,7 @@ export const feedbackRouter = router({
    * Internal procedure for bot handler.
    * Adds optional comment to a feedback response.
    *
-   * @authorization Public (called from bot handler)
+   * @authorization Bot webhook only (requires valid Telegram secret header)
    */
   addComment: botProcedure
     .input(

--- a/backend/src/api/trpc/trpc.ts
+++ b/backend/src/api/trpc/trpc.ts
@@ -19,6 +19,7 @@
  */
 
 import { initTRPC, TRPCError } from '@trpc/server';
+import { timingSafeEqual } from 'crypto';
 import type { Context } from './context.js';
 
 /**
@@ -182,6 +183,44 @@ const isAdmin = t.middleware(({ ctx, next }) => {
  */
 export const authedProcedure = publicProcedure.use(isAuthed);
 
+const isBotWebhook = t.middleware(({ ctx, next }) => {
+  const expected = process.env['TELEGRAM_WEBHOOK_SECRET'];
+
+  if (!expected) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'Bot webhook secret is not configured.',
+    });
+  }
+
+  const received = ctx.requestHeaders?.telegramSecretToken;
+  if (!received) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'Bot webhook signature is required.',
+    });
+  }
+
+  const expectedBuffer = Buffer.from(expected);
+  const receivedBuffer = Buffer.from(received);
+
+  if (expectedBuffer.length !== receivedBuffer.length) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'Invalid bot webhook signature.',
+    });
+  }
+
+  if (!timingSafeEqual(expectedBuffer, receivedBuffer)) {
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'Invalid bot webhook signature.',
+    });
+  }
+
+  return next();
+});
+
 /**
  * Manager procedure (requires admin or manager role)
  *
@@ -245,3 +284,12 @@ export const accountantProcedure = authedProcedure.use(isAccountant);
  * - User management
  */
 export const adminProcedure = authedProcedure.use(isAdmin);
+
+/**
+ * Bot webhook procedure (requires valid Telegram webhook secret header)
+ *
+ * Available to: Telegram webhook requests only
+ *
+ * Use for bot callback write operations exposed via tRPC.
+ */
+export const botProcedure = publicProcedure.use(isBotWebhook);

--- a/backend/src/services/feedback/__tests__/analytics.service.test.ts
+++ b/backend/src/services/feedback/__tests__/analytics.service.test.ts
@@ -1,0 +1,704 @@
+/**
+ * Feedback Analytics Service Tests (gh-324 / ADR-007)
+ *
+ * Covers the unified read model that merges legacy `feedbackResponse` with
+ * post-gh-294 `surveyVote(state='active')`. Uses an in-memory Prisma mock so
+ * we can exercise the real merge/sort logic without a database.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// In-memory store for the mock Prisma client. Declared via vi.hoisted so the
+// (hoisted) vi.mock factory can read it.
+// ---------------------------------------------------------------------------
+const store = vi.hoisted(() => {
+  type LegacyRow = {
+    id: string;
+    chatId: bigint;
+    rating: number;
+    comment: string | null;
+    submittedAt: Date;
+    clientUsername: string | null;
+    surveyId: string | null;
+    deliveryId: string | null;
+    chat: {
+      title: string | null;
+      assignedAccountant: { fullName: string } | null;
+    } | null;
+    survey: { quarter: string | null } | null;
+  };
+
+  type VoteRow = {
+    id: string;
+    deliveryId: string;
+    telegramUserId: bigint;
+    username: string | null;
+    rating: number;
+    comment: string | null;
+    state: 'active' | 'removed';
+    createdAt: Date;
+    updatedAt: Date;
+    delivery: {
+      chatId: bigint;
+      surveyId: string;
+      chat: {
+        title: string | null;
+        assignedAccountant: { fullName: string } | null;
+      } | null;
+      survey: { quarter: string | null } | null;
+    };
+  };
+
+  type SurveyRow = {
+    id: string;
+    quarter: string | null;
+    status: string;
+  };
+
+  const state = {
+    legacy: [] as LegacyRow[],
+    votes: [] as VoteRow[],
+    surveys: [] as SurveyRow[],
+    reset(): void {
+      state.legacy = [];
+      state.votes = [];
+      state.surveys = [];
+    },
+  };
+
+  return { state };
+});
+
+type DateFilter = { gte?: Date; lte?: Date } | undefined;
+
+function matchesDate(value: Date, filter: DateFilter): boolean {
+  if (!filter) return true;
+  if (filter.gte && value < filter.gte) return false;
+  if (filter.lte && value > filter.lte) return false;
+  return true;
+}
+
+function matchesCommentNotNull(filter: { not: null } | undefined, value: string | null): boolean {
+  if (!filter) return true;
+  return value !== null;
+}
+
+function matchesInBigInt(filter: { in: bigint[] } | undefined, value: bigint): boolean {
+  if (!filter) return true;
+  return filter.in.includes(value);
+}
+
+function matchesRatingFilter(
+  filter: { gte?: number; lte?: number } | undefined,
+  rating: number
+): boolean {
+  if (!filter) return true;
+  if (filter.gte !== undefined && rating < filter.gte) return false;
+  if (filter.lte !== undefined && rating > filter.lte) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal Prisma mock. Implements only what analytics.service.ts calls.
+// ---------------------------------------------------------------------------
+const mockPrisma = vi.hoisted(() => {
+  function legacyFindMany(args: {
+    where?: Record<string, unknown>;
+    orderBy?: { submittedAt?: 'asc' | 'desc' };
+    take?: number;
+  }): unknown[] {
+    const where = args.where ?? {};
+    let rows = store.state.legacy.filter((r) => {
+      if (!matchesDate(r.submittedAt, (where as { submittedAt?: DateFilter }).submittedAt))
+        return false;
+      const cw = where as { comment?: { not: null } };
+      if (!matchesCommentNotNull(cw.comment, r.comment)) return false;
+      const sid = (where as { surveyId?: string }).surveyId;
+      if (sid !== undefined && r.surveyId !== sid) return false;
+      const cidFilter = (where as { chatId?: bigint | { in: bigint[] } }).chatId;
+      if (typeof cidFilter === 'bigint') {
+        if (r.chatId !== cidFilter) return false;
+      } else if (!matchesInBigInt(cidFilter, r.chatId)) return false;
+      const rf = (where as { rating?: { gte?: number; lte?: number } }).rating;
+      if (!matchesRatingFilter(rf, r.rating)) return false;
+      return true;
+    });
+    if (args.orderBy?.submittedAt === 'desc') {
+      rows = [...rows].sort((a, b) => b.submittedAt.getTime() - a.submittedAt.getTime());
+    }
+    if (args.take !== undefined) rows = rows.slice(0, args.take);
+    return rows;
+  }
+
+  function voteFindMany(args: {
+    where?: Record<string, unknown>;
+    orderBy?: { updatedAt?: 'asc' | 'desc' };
+    take?: number;
+  }): unknown[] {
+    const where = args.where ?? {};
+    let rows = store.state.votes.filter((v) => {
+      const stateFilter = (where as { state?: 'active' | 'removed' }).state;
+      if (stateFilter !== undefined && v.state !== stateFilter) return false;
+      if (!matchesDate(v.updatedAt, (where as { updatedAt?: DateFilter }).updatedAt)) return false;
+      const cw = where as { comment?: { not: null } };
+      if (!matchesCommentNotNull(cw.comment, v.comment)) return false;
+      const delivery = (
+        where as {
+          delivery?: {
+            surveyId?: string;
+            chatId?: bigint | { in: bigint[] };
+          };
+        }
+      ).delivery;
+      if (delivery) {
+        if (delivery.surveyId !== undefined && v.delivery.surveyId !== delivery.surveyId)
+          return false;
+        const cidFilter = delivery.chatId;
+        if (typeof cidFilter === 'bigint') {
+          if (v.delivery.chatId !== cidFilter) return false;
+        } else if (!matchesInBigInt(cidFilter, v.delivery.chatId)) return false;
+      }
+      const rf = (where as { rating?: { gte?: number; lte?: number } }).rating;
+      if (!matchesRatingFilter(rf, v.rating)) return false;
+      return true;
+    });
+    if (args.orderBy?.updatedAt === 'desc') {
+      rows = [...rows].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+    }
+    if (args.take !== undefined) rows = rows.slice(0, args.take);
+    return rows;
+  }
+
+  return {
+    feedbackResponse: {
+      findMany: vi.fn(legacyFindMany),
+      count: vi.fn((args: { where?: Record<string, unknown> }) => {
+        return legacyFindMany({ where: args.where }).length;
+      }),
+    },
+    surveyVote: {
+      findMany: vi.fn(voteFindMany),
+    },
+    feedbackSurvey: {
+      findUnique: vi.fn(async ({ where }: { where: { id: string } }) => {
+        return store.state.surveys.find((s) => s.id === where.id) ?? null;
+      }),
+    },
+  };
+});
+
+vi.mock('../../../lib/prisma.js', () => ({
+  prisma: mockPrisma,
+}));
+
+vi.mock('../../../utils/logger.js', () => ({
+  default: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Import AFTER mocks.
+import {
+  fetchUnifiedRatings,
+  fetchUnifiedEntries,
+  fetchUnifiedComments,
+  getAggregates,
+  getTrendData,
+  getRecentComments,
+} from '../analytics.service.js';
+
+// ---------------------------------------------------------------------------
+// Helpers to seed rows.
+// ---------------------------------------------------------------------------
+
+let seq = 0;
+const uuid = (prefix: string): string =>
+  `${prefix}-${(++seq).toString().padStart(12, '0')}-0000-0000-0000-000000000000`;
+
+function legacy(attrs: {
+  rating: number;
+  submittedAt: Date;
+  chatId?: bigint;
+  surveyId?: string | null;
+  comment?: string | null;
+  clientUsername?: string | null;
+  quarter?: string | null;
+  accountantName?: string | null;
+  chatTitle?: string | null;
+}): void {
+  store.state.legacy.push({
+    id: uuid('fr'),
+    chatId: attrs.chatId ?? 1000n,
+    rating: attrs.rating,
+    comment: attrs.comment ?? null,
+    submittedAt: attrs.submittedAt,
+    clientUsername: attrs.clientUsername ?? null,
+    surveyId: attrs.surveyId ?? null,
+    deliveryId: null,
+    chat: {
+      title: attrs.chatTitle ?? 'Legacy Chat',
+      assignedAccountant: attrs.accountantName ? { fullName: attrs.accountantName } : null,
+    },
+    survey: attrs.surveyId ? { quarter: attrs.quarter ?? '2025-Q1' } : null,
+  });
+}
+
+function vote(attrs: {
+  rating: number;
+  updatedAt: Date;
+  createdAt?: Date;
+  chatId?: bigint;
+  surveyId?: string;
+  comment?: string | null;
+  username?: string | null;
+  telegramUserId?: bigint;
+  state?: 'active' | 'removed';
+  quarter?: string | null;
+  deliveryId?: string;
+  accountantName?: string | null;
+  chatTitle?: string | null;
+}): void {
+  store.state.votes.push({
+    id: uuid('sv'),
+    deliveryId: attrs.deliveryId ?? uuid('del'),
+    telegramUserId: attrs.telegramUserId ?? 1n,
+    username: attrs.username ?? null,
+    rating: attrs.rating,
+    comment: attrs.comment ?? null,
+    state: attrs.state ?? 'active',
+    createdAt: attrs.createdAt ?? attrs.updatedAt,
+    updatedAt: attrs.updatedAt,
+    delivery: {
+      chatId: attrs.chatId ?? 2000n,
+      surveyId: attrs.surveyId ?? uuid('sur'),
+      chat: {
+        title: attrs.chatTitle ?? 'Vote Chat',
+        assignedAccountant: attrs.accountantName ? { fullName: attrs.accountantName } : null,
+      },
+      survey: { quarter: attrs.quarter ?? '2026-Q1' },
+    },
+  });
+}
+
+beforeEach(() => {
+  store.state.reset();
+  seq = 0;
+  vi.clearAllMocks();
+});
+
+// ===========================================================================
+// fetchUnifiedRatings
+// ===========================================================================
+
+describe('fetchUnifiedRatings', () => {
+  it('legacy-only: returns all legacy rows', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01') });
+    legacy({ rating: 3, submittedAt: new Date('2025-03-15') });
+
+    const rows = await fetchUnifiedRatings({});
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.rating).sort()).toEqual([3, 5]);
+  });
+
+  it('vote-only: returns only active vote rows', async () => {
+    vote({ rating: 4, updatedAt: new Date('2026-04-01') });
+    vote({ rating: 2, updatedAt: new Date('2026-04-02'), state: 'removed' });
+
+    const rows = await fetchUnifiedRatings({});
+    expect(rows).toHaveLength(1);
+    expect(rows[0].rating).toBe(4);
+  });
+
+  it('mixed: sums both sources', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01') });
+    vote({ rating: 1, updatedAt: new Date('2026-04-01') });
+
+    const rows = await fetchUnifiedRatings({});
+    expect(rows).toHaveLength(2);
+  });
+
+  it('excludes removed votes', async () => {
+    vote({ rating: 5, updatedAt: new Date('2026-04-01'), state: 'active' });
+    vote({ rating: 1, updatedAt: new Date('2026-04-02'), state: 'removed' });
+
+    const rows = await fetchUnifiedRatings({});
+    expect(rows.map((r) => r.rating)).toEqual([5]);
+  });
+
+  it('date bounds apply to submittedAt (legacy) and updatedAt (votes)', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-01-15') }); // in range
+    legacy({ rating: 4, submittedAt: new Date('2024-12-15') }); // out
+    vote({ rating: 3, updatedAt: new Date('2025-01-20') }); // in range
+    vote({ rating: 2, updatedAt: new Date('2025-02-05') }); // out
+
+    const rows = await fetchUnifiedRatings({
+      dateFrom: new Date('2025-01-01'),
+      dateTo: new Date('2025-01-31'),
+    });
+    expect(rows.map((r) => r.rating).sort()).toEqual([3, 5]);
+  });
+
+  it('scopedChatIds applies to both sources', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01'), chatId: 100n });
+    legacy({ rating: 4, submittedAt: new Date('2025-03-02'), chatId: 200n });
+    vote({ rating: 3, updatedAt: new Date('2026-04-01'), chatId: 100n });
+    vote({ rating: 2, updatedAt: new Date('2026-04-02'), chatId: 300n });
+
+    const rows = await fetchUnifiedRatings({ scopedChatIds: [100n] });
+    expect(rows.map((r) => r.rating).sort()).toEqual([3, 5]);
+  });
+
+  it('surveyId filter applies to both sources', async () => {
+    const s = uuid('sur');
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01'), surveyId: s });
+    legacy({ rating: 4, submittedAt: new Date('2025-03-02'), surveyId: uuid('sur') });
+    vote({ rating: 3, updatedAt: new Date('2026-04-01'), surveyId: s });
+    vote({ rating: 2, updatedAt: new Date('2026-04-02'), surveyId: uuid('sur') });
+
+    const rows = await fetchUnifiedRatings({ surveyId: s });
+    expect(rows.map((r) => r.rating).sort()).toEqual([3, 5]);
+  });
+
+  it('invariant: helper does NOT dedup — if the same deliveryId exists in both sources, both rows surface', async () => {
+    // ADR-007 §5: write-periods do not overlap. If they ever did, the helper
+    // must NOT silently hide the violation — both rows must be visible so
+    // the invariant test can catch it.
+    const delId = uuid('del');
+    legacy({
+      rating: 5,
+      submittedAt: new Date('2025-03-01'),
+      chatId: 42n,
+    });
+    // mutate last legacy row to have deliveryId
+    store.state.legacy[store.state.legacy.length - 1].deliveryId = delId;
+    vote({
+      rating: 1,
+      updatedAt: new Date('2026-04-01'),
+      chatId: 42n,
+      deliveryId: delId,
+    });
+
+    const rows = await fetchUnifiedRatings({});
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.rating).sort()).toEqual([1, 5]);
+  });
+});
+
+// ===========================================================================
+// fetchUnifiedEntries
+// ===========================================================================
+
+describe('fetchUnifiedEntries', () => {
+  it('merges and sorts by submittedAt DESC (vote updatedAt)', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01'), chatTitle: 'A' });
+    vote({ rating: 3, updatedAt: new Date('2026-04-01'), chatTitle: 'B' });
+    legacy({ rating: 4, submittedAt: new Date('2025-03-02'), chatTitle: 'C' });
+
+    const { items, total } = await fetchUnifiedEntries({});
+    expect(total).toBe(3);
+    expect(items[0].chatTitle).toBe('B'); // 2026-04-01 newest
+    expect(items[1].chatTitle).toBe('C'); // 2025-03-02
+    expect(items[2].chatTitle).toBe('A'); // 2025-03-01
+  });
+
+  it('tags rows with source', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01') });
+    vote({ rating: 3, updatedAt: new Date('2026-04-01') });
+
+    const { items } = await fetchUnifiedEntries({});
+    const sources = items.map((i) => i.source).sort();
+    expect(sources).toEqual(['legacy', 'vote']);
+  });
+
+  it('maps vote fields to DTO shape (username, chat.title, accountant, quarter)', async () => {
+    vote({
+      rating: 4,
+      updatedAt: new Date('2026-04-15'),
+      chatId: 555n,
+      username: 'alice',
+      chatTitle: 'Acme Ltd',
+      accountantName: 'Bob Smith',
+      quarter: '2026-Q2',
+    });
+
+    const { items } = await fetchUnifiedEntries({});
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      chatId: 555n,
+      chatTitle: 'Acme Ltd',
+      clientUsername: 'alice',
+      accountantName: 'Bob Smith',
+      rating: 4,
+      surveyQuarter: '2026-Q2',
+      source: 'vote',
+    });
+  });
+
+  it('pagination: slices the merged sorted array', async () => {
+    for (let i = 1; i <= 12; i++) {
+      legacy({ rating: 5, submittedAt: new Date(`2025-03-${String(i).padStart(2, '0')}`) });
+    }
+    for (let i = 1; i <= 8; i++) {
+      vote({ rating: 4, updatedAt: new Date(`2026-04-${String(i).padStart(2, '0')}`) });
+    }
+
+    const { items, total } = await fetchUnifiedEntries({ page: 2, pageSize: 10 });
+    expect(total).toBe(20);
+    expect(items).toHaveLength(10);
+  });
+
+  it('rating bounds filter both sources', async () => {
+    legacy({ rating: 1, submittedAt: new Date('2025-03-01') });
+    legacy({ rating: 5, submittedAt: new Date('2025-03-02') });
+    vote({ rating: 2, updatedAt: new Date('2026-04-01') });
+    vote({ rating: 4, updatedAt: new Date('2026-04-02') });
+
+    const { items } = await fetchUnifiedEntries({ minRating: 2, maxRating: 4 });
+    expect(items.map((i) => i.rating).sort()).toEqual([2, 4]);
+  });
+
+  it('multi-user per delivery produces N entries in the list', async () => {
+    const delId = uuid('del');
+    const surveyId = uuid('sur');
+    vote({
+      rating: 5,
+      updatedAt: new Date('2026-04-10'),
+      deliveryId: delId,
+      telegramUserId: 1n,
+      username: 'u1',
+      surveyId,
+    });
+    vote({
+      rating: 3,
+      updatedAt: new Date('2026-04-11'),
+      deliveryId: delId,
+      telegramUserId: 2n,
+      username: 'u2',
+      surveyId,
+    });
+    vote({
+      rating: 4,
+      updatedAt: new Date('2026-04-12'),
+      deliveryId: delId,
+      telegramUserId: 3n,
+      username: 'u3',
+      surveyId,
+    });
+
+    const { items, total } = await fetchUnifiedEntries({});
+    expect(total).toBe(3);
+    expect(items.map((i) => i.clientUsername)).toEqual(['u3', 'u2', 'u1']);
+  });
+
+  it('re-vote (higher updatedAt) bubbles to the top of the sort', async () => {
+    vote({
+      rating: 3,
+      createdAt: new Date('2026-03-01'),
+      updatedAt: new Date('2026-03-01'),
+      username: 'old-vote',
+    });
+    vote({
+      rating: 5,
+      createdAt: new Date('2026-03-02'),
+      updatedAt: new Date('2026-04-20'),
+      username: 'revoted',
+    });
+
+    const { items } = await fetchUnifiedEntries({});
+    expect(items[0].clientUsername).toBe('revoted');
+  });
+
+  it('scopedChatIds applies to both sources in entries', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01'), chatId: 1n });
+    legacy({ rating: 4, submittedAt: new Date('2025-03-02'), chatId: 2n });
+    vote({ rating: 3, updatedAt: new Date('2026-04-01'), chatId: 1n });
+    vote({ rating: 2, updatedAt: new Date('2026-04-02'), chatId: 3n });
+
+    const { items, total } = await fetchUnifiedEntries({ scopedChatIds: [1n] });
+    expect(total).toBe(2);
+    expect(items.map((i) => i.rating).sort()).toEqual([3, 5]);
+  });
+
+  it('chatId filter narrows both sources', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01'), chatId: 100n });
+    legacy({ rating: 4, submittedAt: new Date('2025-03-02'), chatId: 200n });
+    vote({ rating: 3, updatedAt: new Date('2026-04-01'), chatId: 100n });
+    vote({ rating: 2, updatedAt: new Date('2026-04-02'), chatId: 300n });
+
+    const { items } = await fetchUnifiedEntries({ chatId: 100n });
+    expect(items).toHaveLength(2);
+    expect(items.map((i) => i.rating).sort()).toEqual([3, 5]);
+  });
+});
+
+// ===========================================================================
+// fetchUnifiedComments
+// ===========================================================================
+
+describe('fetchUnifiedComments', () => {
+  it('returns merged comments sorted DESC', async () => {
+    legacy({
+      rating: 5,
+      submittedAt: new Date('2025-03-01'),
+      comment: 'legacy comment',
+    });
+    vote({
+      rating: 3,
+      updatedAt: new Date('2026-04-05'),
+      comment: 'vote comment',
+    });
+    vote({
+      rating: 4,
+      updatedAt: new Date('2026-04-01'),
+      comment: null, // filtered out
+    });
+
+    const rows = await fetchUnifiedComments({ limit: 10 });
+    expect(rows).toHaveLength(2);
+    expect(rows[0].comment).toBe('vote comment'); // newer
+  });
+
+  it('re-vote lifts comment to top (updatedAt semantics)', async () => {
+    vote({
+      rating: 2,
+      createdAt: new Date('2026-02-10'),
+      updatedAt: new Date('2026-02-10'),
+      comment: 'old',
+    });
+    vote({
+      rating: 5,
+      createdAt: new Date('2026-02-15'),
+      updatedAt: new Date('2026-04-20'),
+      comment: 'freshly revoted',
+    });
+
+    const rows = await fetchUnifiedComments({ limit: 10 });
+    expect(rows[0].comment).toBe('freshly revoted');
+  });
+
+  it('limit applies after merge', async () => {
+    for (let i = 1; i <= 15; i++) {
+      legacy({
+        rating: 5,
+        submittedAt: new Date(`2025-03-${String(i).padStart(2, '0')}`),
+        comment: `legacy ${i}`,
+      });
+    }
+    for (let i = 1; i <= 5; i++) {
+      vote({
+        rating: 4,
+        updatedAt: new Date(`2026-04-${String(i).padStart(2, '0')}`),
+        comment: `vote ${i}`,
+      });
+    }
+
+    const rows = await fetchUnifiedComments({ limit: 10 });
+    expect(rows).toHaveLength(10);
+    // Top 10 by date desc — 5 votes (April 2026) + 5 newest legacy (March 15, 14, 13, 12, 11).
+    expect(rows.slice(0, 5).every((r) => r.comment?.startsWith('vote'))).toBe(true);
+  });
+});
+
+// ===========================================================================
+// getAggregates (unified)
+// ===========================================================================
+
+describe('getAggregates (unified)', () => {
+  it('legacy-only scenario', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01') });
+    legacy({ rating: 4, submittedAt: new Date('2025-03-02') });
+    legacy({ rating: 3, submittedAt: new Date('2025-03-03') });
+
+    const agg = await getAggregates();
+    expect(agg.totalResponses).toBe(3);
+    expect(agg.averageRating).toBe(4);
+    expect(agg.nps.promoters).toBe(2); // 5, 4
+    expect(agg.nps.detractors).toBe(1); // 3
+  });
+
+  it('vote-only scenario', async () => {
+    vote({ rating: 5, updatedAt: new Date('2026-04-01') });
+    vote({ rating: 5, updatedAt: new Date('2026-04-02') });
+
+    const agg = await getAggregates();
+    expect(agg.totalResponses).toBe(2);
+    expect(agg.averageRating).toBe(5);
+    expect(agg.nps.score).toBe(100);
+  });
+
+  it('mixed scenario sums both sources', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01') });
+    vote({ rating: 1, updatedAt: new Date('2026-04-01') });
+
+    const agg = await getAggregates();
+    expect(agg.totalResponses).toBe(2);
+    expect(agg.averageRating).toBe(3); // (5+1)/2
+  });
+
+  it('ignores removed votes', async () => {
+    vote({ rating: 5, updatedAt: new Date('2026-04-01'), state: 'active' });
+    vote({ rating: 1, updatedAt: new Date('2026-04-02'), state: 'removed' });
+
+    const agg = await getAggregates();
+    expect(agg.totalResponses).toBe(1);
+    expect(agg.averageRating).toBe(5);
+  });
+});
+
+// ===========================================================================
+// getTrendData (quarters — union)
+// ===========================================================================
+
+describe('getTrendData (unified, quarters)', () => {
+  it('buckets rows from both sources into the correct quarter', async () => {
+    // Current moment is 2026-Q2 (April 20, 2026). Request 5 quarters: 2025-Q2..2026-Q2.
+    legacy({ rating: 5, submittedAt: new Date('2025-05-15') }); // 2025-Q2
+    legacy({ rating: 4, submittedAt: new Date('2025-08-15') }); // 2025-Q3
+    vote({ rating: 3, updatedAt: new Date('2026-01-15') }); // 2026-Q1
+    vote({ rating: 2, updatedAt: new Date('2026-04-10') }); // 2026-Q2
+
+    vi.setSystemTime(new Date('2026-04-20T12:00:00Z'));
+
+    const trend = await getTrendData(5);
+    const byPeriod = Object.fromEntries(trend.map((t) => [t.period, t.responseCount]));
+
+    expect(byPeriod['2025-Q2']).toBe(1);
+    expect(byPeriod['2025-Q3']).toBe(1);
+    expect(byPeriod['2026-Q1']).toBe(1);
+    expect(byPeriod['2026-Q2']).toBe(1);
+
+    vi.useRealTimers();
+  });
+});
+
+// ===========================================================================
+// getRecentComments (unified)
+// ===========================================================================
+
+describe('getRecentComments (unified)', () => {
+  it('returns comments from both sources (newest first)', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01'), comment: 'old-legacy' });
+    vote({ rating: 4, updatedAt: new Date('2026-04-10'), comment: 'new-vote' });
+
+    const rows = await getRecentComments(5, false);
+    expect(rows.map((r) => r.comment)).toEqual(['new-vote', 'old-legacy']);
+  });
+
+  it('includes client info when requested', async () => {
+    vote({
+      rating: 2,
+      updatedAt: new Date('2026-04-10'),
+      comment: 'bad',
+      chatId: 777n,
+      username: 'alice',
+    });
+
+    const rows = await getRecentComments(1, true);
+    expect(rows[0].chatId).toBe('777');
+    expect(rows[0].clientUsername).toBe('alice');
+  });
+});

--- a/backend/src/services/feedback/__tests__/analytics.service.test.ts
+++ b/backend/src/services/feedback/__tests__/analytics.service.test.ts
@@ -533,6 +533,38 @@ describe('fetchUnifiedEntries', () => {
     expect(items).toHaveLength(2);
     expect(items.map((i) => i.rating).sort()).toEqual([3, 5]);
   });
+
+  it('chatId+scope intersection keeps in-scope chat results', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01'), chatId: 100n });
+    legacy({ rating: 4, submittedAt: new Date('2025-03-02'), chatId: 200n });
+    vote({ rating: 3, updatedAt: new Date('2026-04-01'), chatId: 100n });
+    vote({ rating: 2, updatedAt: new Date('2026-04-02'), chatId: 200n });
+
+    const { items, total } = await fetchUnifiedEntries({
+      scopedChatIds: [100n],
+      chatId: 100n,
+    });
+
+    expect(total).toBe(2);
+    expect(items).toHaveLength(2);
+    expect(items.every((i) => i.chatId === 100n)).toBe(true);
+    expect(items.map((i) => i.rating).sort()).toEqual([3, 5]);
+  });
+
+  it('chatId+scope intersection returns empty for out-of-scope chat', async () => {
+    legacy({ rating: 5, submittedAt: new Date('2025-03-01'), chatId: 100n });
+    vote({ rating: 3, updatedAt: new Date('2026-04-01'), chatId: 100n });
+    legacy({ rating: 4, submittedAt: new Date('2025-03-02'), chatId: 200n });
+    vote({ rating: 2, updatedAt: new Date('2026-04-02'), chatId: 200n });
+
+    const { items, total } = await fetchUnifiedEntries({
+      scopedChatIds: [100n],
+      chatId: 200n,
+    });
+
+    expect(total).toBe(0);
+    expect(items).toHaveLength(0);
+  });
 });
 
 // ===========================================================================

--- a/backend/src/services/feedback/analytics.service.ts
+++ b/backend/src/services/feedback/analytics.service.ts
@@ -216,11 +216,11 @@ export async function fetchUnifiedEntries(
   opts: UnifiedEntryFilters & { page?: number; pageSize?: number }
 ): Promise<{ items: UnifiedEntryRow[]; total: number }> {
   const timeFilter = buildTimeFilter(opts.dateFrom, opts.dateTo);
-  const hasScopedChatIds = Array.isArray(opts.scopedChatIds);
+  const scopedChatIds = Array.isArray(opts.scopedChatIds) ? opts.scopedChatIds : undefined;
 
   // Intersection guard: when both scope and explicit chatId are supplied,
   // the explicit chat must belong to scope, otherwise return an empty result.
-  if (hasScopedChatIds && opts.chatId !== undefined && !opts.scopedChatIds.includes(opts.chatId)) {
+  if (scopedChatIds && opts.chatId !== undefined && !scopedChatIds.includes(opts.chatId)) {
     return { items: [], total: 0 };
   }
 
@@ -229,8 +229,8 @@ export async function fetchUnifiedEntries(
   if (opts.surveyId) legacyWhere.surveyId = opts.surveyId;
   if (opts.chatId !== undefined) {
     legacyWhere.chatId = opts.chatId;
-  } else if (hasScopedChatIds) {
-    legacyWhere.chatId = { in: opts.scopedChatIds };
+  } else if (scopedChatIds) {
+    legacyWhere.chatId = { in: scopedChatIds };
   }
   if (opts.minRating !== undefined || opts.maxRating !== undefined) {
     const ratingFilter: Prisma.IntFilter = {};
@@ -242,14 +242,14 @@ export async function fetchUnifiedEntries(
   const voteWhere: Prisma.SurveyVoteWhereInput = { state: 'active' };
   if (timeFilter) voteWhere.updatedAt = timeFilter;
   const needsDeliveryJoin =
-    opts.surveyId !== undefined || hasScopedChatIds || opts.chatId !== undefined;
+    opts.surveyId !== undefined || scopedChatIds !== undefined || opts.chatId !== undefined;
   if (needsDeliveryJoin) {
     const deliveryWhere: Prisma.SurveyDeliveryWhereInput = {};
     if (opts.surveyId) deliveryWhere.surveyId = opts.surveyId;
     if (opts.chatId !== undefined) {
       deliveryWhere.chatId = opts.chatId;
-    } else if (hasScopedChatIds) {
-      deliveryWhere.chatId = { in: opts.scopedChatIds };
+    } else if (scopedChatIds) {
+      deliveryWhere.chatId = { in: scopedChatIds };
     }
     voteWhere.delivery = deliveryWhere;
   }

--- a/backend/src/services/feedback/analytics.service.ts
+++ b/backend/src/services/feedback/analytics.service.ts
@@ -8,9 +8,27 @@
  *
  * NPS Formula: % Promoters (4-5) - % Detractors (1-3)
  *
+ * ## Unified read model (gh-324 / ADR-007)
+ *
+ * Read-path unifies two write sources:
+ *   - `FeedbackResponse` — legacy, historical rows pre-gh-294 (immutable).
+ *   - `SurveyVote (state='active')` — canonical, multi-user voting post-gh-294.
+ *
+ * The unified helpers below (`fetchUnifiedRatings`, `fetchUnifiedEntries`,
+ * `fetchUnifiedComments`) issue both queries in parallel via `Promise.all`,
+ * then merge and sort in memory. Prisma does not support UNION natively; at
+ * /feedback volumes (<10k rows per tenant) the in-memory merge is cheap.
+ *
+ * Public API signatures (`getAggregates`, `getTrendData`, `getRecentComments`,
+ * `getSurveySummary`) are UNCHANGED — callers need not care about the
+ * underlying UNION. Dedup is NOT performed: write-periods do not overlap by
+ * design (see ADR-007 §5). The `no-deliveryId-in-both` invariant is enforced
+ * by tests as a safety net.
+ *
  * @module services/feedback/analytics
  */
 
+import type { Prisma } from '@prisma/client';
 import { prisma } from '../../lib/prisma.js';
 import logger from '../../utils/logger.js';
 
@@ -50,6 +68,339 @@ export interface TrendDataPoint {
 export interface DateRange {
   from?: Date;
   to?: Date;
+}
+
+// ============================================================================
+// UNIFIED READ HELPERS (gh-324 / ADR-007)
+// ============================================================================
+
+/**
+ * Shape of a unified rating row, used by aggregate/trend calculations.
+ * Minimal fields (no joins) to keep the query light.
+ */
+export interface UnifiedRatingRow {
+  rating: number;
+  submittedAt: Date; // For SurveyVote rows this is `updatedAt` (see ADR-007 §4).
+  chatId: bigint;
+  surveyId: string | null;
+}
+
+/**
+ * Shape of a unified feedback entry row — full DTO for listings and export.
+ *
+ * Field mapping (legacy → vote):
+ *   id               → response.id                              / vote.id
+ *   chatId           → response.chatId                          / vote.delivery.chatId
+ *   chatTitle        → response.chat.title                      / vote.delivery.chat.title
+ *   clientUsername   → response.clientUsername                  / vote.username
+ *   accountantName   → response.chat.assignedAccountant.fullName / vote.delivery.chat.assignedAccountant.fullName
+ *   rating           → response.rating                          / vote.rating
+ *   comment          → response.comment                         / vote.comment
+ *   submittedAt      → response.submittedAt                     / vote.updatedAt
+ *   surveyId         → response.surveyId                        / vote.delivery.surveyId
+ *   surveyQuarter    → response.survey.quarter                  / vote.delivery.survey.quarter
+ */
+export interface UnifiedEntryRow {
+  id: string;
+  chatId: bigint;
+  chatTitle: string | null;
+  clientUsername: string | null;
+  accountantName: string | null;
+  rating: number;
+  comment: string | null;
+  submittedAt: Date;
+  surveyId: string | null;
+  surveyQuarter: string | null;
+  source: 'legacy' | 'vote';
+}
+
+interface UnifiedReadFilters {
+  dateFrom?: Date | undefined;
+  dateTo?: Date | undefined;
+  surveyId?: string | undefined;
+  /** Optional chat scoping. `null` = no restriction (admin). */
+  scopedChatIds?: bigint[] | null | undefined;
+}
+
+interface UnifiedEntryFilters extends UnifiedReadFilters {
+  minRating?: number | undefined;
+  maxRating?: number | undefined;
+  /** Chat filter applied independently from scoping. */
+  chatId?: bigint | undefined;
+}
+
+/**
+ * Build the common submitted-at/updated-at range filter.
+ * Returns `undefined` when no bounds are present (so we can spread conditionally).
+ */
+function buildTimeFilter(dateFrom?: Date, dateTo?: Date): Prisma.DateTimeFilter | undefined {
+  if (!dateFrom && !dateTo) return undefined;
+  const filter: Prisma.DateTimeFilter = {};
+  if (dateFrom) filter.gte = dateFrom;
+  if (dateTo) filter.lte = dateTo;
+  return filter;
+}
+
+/**
+ * Parallel read of legacy `feedbackResponse` + active `surveyVote` rows,
+ * merged into a single `UnifiedRatingRow[]` for lightweight aggregation.
+ *
+ * Note: the helper does NOT deduplicate by deliveryId — dedup is a write-time
+ * invariant (see ADR-007 §5). If the invariant is violated in the future the
+ * caller would see two rows for the same delivery — this is intentional so
+ * that the violation surfaces rather than being silently hidden.
+ */
+export async function fetchUnifiedRatings(opts: UnifiedReadFilters): Promise<UnifiedRatingRow[]> {
+  const timeFilter = buildTimeFilter(opts.dateFrom, opts.dateTo);
+
+  const legacyWhere: Prisma.FeedbackResponseWhereInput = {};
+  if (timeFilter) legacyWhere.submittedAt = timeFilter;
+  if (opts.surveyId) legacyWhere.surveyId = opts.surveyId;
+  if (opts.scopedChatIds) legacyWhere.chatId = { in: opts.scopedChatIds };
+
+  const voteWhere: Prisma.SurveyVoteWhereInput = { state: 'active' };
+  if (timeFilter) voteWhere.updatedAt = timeFilter;
+  if (opts.surveyId || opts.scopedChatIds) {
+    const deliveryWhere: Prisma.SurveyDeliveryWhereInput = {};
+    if (opts.surveyId) deliveryWhere.surveyId = opts.surveyId;
+    if (opts.scopedChatIds) deliveryWhere.chatId = { in: opts.scopedChatIds };
+    voteWhere.delivery = deliveryWhere;
+  }
+
+  const [legacy, votes] = await Promise.all([
+    prisma.feedbackResponse.findMany({
+      where: legacyWhere,
+      select: {
+        rating: true,
+        submittedAt: true,
+        chatId: true,
+        surveyId: true,
+      },
+    }),
+    prisma.surveyVote.findMany({
+      where: voteWhere,
+      select: {
+        rating: true,
+        updatedAt: true,
+        delivery: {
+          select: { chatId: true, surveyId: true },
+        },
+      },
+    }),
+  ]);
+
+  const out: UnifiedRatingRow[] = [
+    ...legacy.map((r) => ({
+      rating: r.rating,
+      submittedAt: r.submittedAt,
+      chatId: r.chatId,
+      surveyId: r.surveyId,
+    })),
+    ...votes.map((v) => ({
+      rating: v.rating,
+      submittedAt: v.updatedAt,
+      chatId: v.delivery.chatId,
+      surveyId: v.delivery.surveyId,
+    })),
+  ];
+
+  return out;
+}
+
+/**
+ * Parallel read of full feedback entries from both sources, optionally
+ * paginated. `total` is the raw count (before pagination) and includes
+ * rows from both sources.
+ */
+export async function fetchUnifiedEntries(
+  opts: UnifiedEntryFilters & { page?: number; pageSize?: number }
+): Promise<{ items: UnifiedEntryRow[]; total: number }> {
+  const timeFilter = buildTimeFilter(opts.dateFrom, opts.dateTo);
+
+  const legacyWhere: Prisma.FeedbackResponseWhereInput = {};
+  if (timeFilter) legacyWhere.submittedAt = timeFilter;
+  if (opts.surveyId) legacyWhere.surveyId = opts.surveyId;
+  if (opts.scopedChatIds) legacyWhere.chatId = { in: opts.scopedChatIds };
+  if (opts.chatId !== undefined) legacyWhere.chatId = opts.chatId;
+  if (opts.minRating !== undefined || opts.maxRating !== undefined) {
+    const ratingFilter: Prisma.IntFilter = {};
+    if (opts.minRating !== undefined) ratingFilter.gte = opts.minRating;
+    if (opts.maxRating !== undefined) ratingFilter.lte = opts.maxRating;
+    legacyWhere.rating = ratingFilter;
+  }
+
+  const voteWhere: Prisma.SurveyVoteWhereInput = { state: 'active' };
+  if (timeFilter) voteWhere.updatedAt = timeFilter;
+  const needsDeliveryJoin =
+    opts.surveyId !== undefined || opts.scopedChatIds !== undefined || opts.chatId !== undefined;
+  if (needsDeliveryJoin) {
+    const deliveryWhere: Prisma.SurveyDeliveryWhereInput = {};
+    if (opts.surveyId) deliveryWhere.surveyId = opts.surveyId;
+    if (opts.scopedChatIds) deliveryWhere.chatId = { in: opts.scopedChatIds };
+    if (opts.chatId !== undefined) deliveryWhere.chatId = opts.chatId;
+    voteWhere.delivery = deliveryWhere;
+  }
+  if (opts.minRating !== undefined || opts.maxRating !== undefined) {
+    const ratingFilter: Prisma.IntFilter = {};
+    if (opts.minRating !== undefined) ratingFilter.gte = opts.minRating;
+    if (opts.maxRating !== undefined) ratingFilter.lte = opts.maxRating;
+    voteWhere.rating = ratingFilter;
+  }
+
+  const [legacyRows, voteRows] = await Promise.all([
+    prisma.feedbackResponse.findMany({
+      where: legacyWhere,
+      include: {
+        chat: {
+          include: {
+            assignedAccountant: { select: { fullName: true } },
+          },
+        },
+        survey: { select: { quarter: true } },
+      },
+      orderBy: { submittedAt: 'desc' },
+    }),
+    prisma.surveyVote.findMany({
+      where: voteWhere,
+      include: {
+        delivery: {
+          include: {
+            chat: {
+              include: {
+                assignedAccountant: { select: { fullName: true } },
+              },
+            },
+            survey: { select: { quarter: true } },
+          },
+        },
+      },
+      orderBy: { updatedAt: 'desc' },
+    }),
+  ]);
+
+  const merged: UnifiedEntryRow[] = [
+    ...legacyRows.map((r) => ({
+      id: r.id,
+      chatId: r.chatId,
+      chatTitle: r.chat?.title ?? null,
+      clientUsername: r.clientUsername,
+      accountantName: r.chat?.assignedAccountant?.fullName ?? null,
+      rating: r.rating,
+      comment: r.comment,
+      submittedAt: r.submittedAt,
+      surveyId: r.surveyId,
+      surveyQuarter: r.survey?.quarter ?? null,
+      source: 'legacy' as const,
+    })),
+    ...voteRows.map((v) => ({
+      id: v.id,
+      chatId: v.delivery.chatId,
+      chatTitle: v.delivery.chat?.title ?? null,
+      clientUsername: v.username,
+      accountantName: v.delivery.chat?.assignedAccountant?.fullName ?? null,
+      rating: v.rating,
+      comment: v.comment,
+      submittedAt: v.updatedAt,
+      surveyId: v.delivery.surveyId,
+      surveyQuarter: v.delivery.survey?.quarter ?? null,
+      source: 'vote' as const,
+    })),
+  ];
+
+  // Global merge-sort by submittedAt DESC (tie-break by id for stability).
+  merged.sort((a, b) => {
+    const diff = b.submittedAt.getTime() - a.submittedAt.getTime();
+    return diff !== 0 ? diff : a.id.localeCompare(b.id);
+  });
+
+  const total = merged.length;
+
+  let items = merged;
+  if (opts.page !== undefined && opts.pageSize !== undefined) {
+    const skip = (opts.page - 1) * opts.pageSize;
+    items = merged.slice(skip, skip + opts.pageSize);
+  }
+
+  return { items, total };
+}
+
+/**
+ * Parallel read of comments (only rows with non-null comment) from both
+ * sources, sorted by submittedAt DESC and limited.
+ */
+export async function fetchUnifiedComments(
+  opts: UnifiedReadFilters & { limit: number }
+): Promise<
+  Array<Pick<UnifiedEntryRow, 'comment' | 'rating' | 'submittedAt' | 'chatId' | 'clientUsername'>>
+> {
+  const timeFilter = buildTimeFilter(opts.dateFrom, opts.dateTo);
+
+  const legacyWhere: Prisma.FeedbackResponseWhereInput = { comment: { not: null } };
+  if (timeFilter) legacyWhere.submittedAt = timeFilter;
+  if (opts.surveyId) legacyWhere.surveyId = opts.surveyId;
+  if (opts.scopedChatIds) legacyWhere.chatId = { in: opts.scopedChatIds };
+
+  const voteWhere: Prisma.SurveyVoteWhereInput = {
+    state: 'active',
+    comment: { not: null },
+  };
+  if (timeFilter) voteWhere.updatedAt = timeFilter;
+  if (opts.surveyId || opts.scopedChatIds) {
+    const deliveryWhere: Prisma.SurveyDeliveryWhereInput = {};
+    if (opts.surveyId) deliveryWhere.surveyId = opts.surveyId;
+    if (opts.scopedChatIds) deliveryWhere.chatId = { in: opts.scopedChatIds };
+    voteWhere.delivery = deliveryWhere;
+  }
+
+  const [legacy, votes] = await Promise.all([
+    prisma.feedbackResponse.findMany({
+      where: legacyWhere,
+      select: {
+        comment: true,
+        rating: true,
+        submittedAt: true,
+        chatId: true,
+        clientUsername: true,
+      },
+      orderBy: { submittedAt: 'desc' },
+      take: opts.limit,
+    }),
+    prisma.surveyVote.findMany({
+      where: voteWhere,
+      select: {
+        comment: true,
+        rating: true,
+        updatedAt: true,
+        username: true,
+        delivery: { select: { chatId: true } },
+      },
+      orderBy: { updatedAt: 'desc' },
+      take: opts.limit,
+    }),
+  ]);
+
+  const merged: Array<
+    Pick<UnifiedEntryRow, 'comment' | 'rating' | 'submittedAt' | 'chatId' | 'clientUsername'>
+  > = [
+    ...legacy.map((r) => ({
+      comment: r.comment,
+      rating: r.rating,
+      submittedAt: r.submittedAt,
+      chatId: r.chatId,
+      clientUsername: r.clientUsername,
+    })),
+    ...votes.map((v) => ({
+      comment: v.comment,
+      rating: v.rating,
+      submittedAt: v.updatedAt,
+      chatId: v.delivery.chatId,
+      clientUsername: v.username,
+    })),
+  ];
+
+  merged.sort((a, b) => b.submittedAt.getTime() - a.submittedAt.getTime());
+
+  return merged.slice(0, opts.limit);
 }
 
 // ============================================================================
@@ -125,7 +476,9 @@ export function calculateDistribution(ratings: number[]): RatingDistribution[] {
 }
 
 /**
- * Get aggregate feedback statistics
+ * Get aggregate feedback statistics.
+ *
+ * Reads from `feedbackResponse ∪ surveyVote(active)` (see ADR-007).
  *
  * @param dateRange - Optional date filter
  * @param surveyId - Optional survey filter
@@ -135,26 +488,13 @@ export async function getAggregates(
   dateRange?: DateRange,
   surveyId?: string
 ): Promise<FeedbackAggregates> {
-  // Build where clause with proper typing
-  const submittedAtFilter: { gte?: Date; lte?: Date } | undefined =
-    dateRange?.from || dateRange?.to
-      ? {
-          ...(dateRange.from && { gte: dateRange.from }),
-          ...(dateRange.to && { lte: dateRange.to }),
-        }
-      : undefined;
-
-  const responses = await prisma.feedbackResponse.findMany({
-    where: {
-      ...(submittedAtFilter && { submittedAt: submittedAtFilter }),
-      ...(surveyId && { surveyId }),
-    },
-    select: {
-      rating: true,
-    },
+  const rows = await fetchUnifiedRatings({
+    dateFrom: dateRange?.from,
+    dateTo: dateRange?.to,
+    surveyId,
   });
 
-  const ratings = responses.map((r) => r.rating);
+  const ratings = rows.map((r) => r.rating);
   const totalResponses = ratings.length;
 
   const averageRating =
@@ -183,58 +523,65 @@ export async function getAggregates(
 }
 
 /**
- * Get trend data grouped by quarter
+ * Get trend data grouped by quarter.
+ *
+ * Reads from `feedbackResponse ∪ surveyVote(active)` (see ADR-007). Rows are
+ * bucketed by quarter in memory using the unified `submittedAt` timestamp
+ * (which is `updatedAt` for vote rows — re-votes shift the bucket).
  *
  * @param quarters - Number of quarters to include (default: 4)
- * @returns Array of trend data points
+ * @returns Array of trend data points (oldest first)
  */
 export async function getTrendData(quarters: number = 4): Promise<TrendDataPoint[]> {
-  // Get date range for the specified number of quarters
   const now = new Date();
   const currentQuarter = Math.floor(now.getMonth() / 3) + 1;
   const currentYear = now.getFullYear();
 
-  const results: TrendDataPoint[] = [];
+  // Compute the oldest quarter we care about to narrow the DB read window.
+  let oldestQuarter = currentQuarter - (quarters - 1);
+  let oldestYear = currentYear;
+  while (oldestQuarter <= 0) {
+    oldestQuarter += 4;
+    oldestYear -= 1;
+  }
+  const windowStart = new Date(oldestYear, (oldestQuarter - 1) * 3, 1);
+  const windowEnd = new Date(currentYear, currentQuarter * 3, 0, 23, 59, 59);
 
+  const rows = await fetchUnifiedRatings({
+    dateFrom: windowStart,
+    dateTo: windowEnd,
+  });
+
+  // Bucket by quarter label "YYYY-QN".
+  const buckets = new Map<string, number[]>();
   for (let i = 0; i < quarters; i++) {
     let quarter = currentQuarter - i;
     let year = currentYear;
-
     while (quarter <= 0) {
       quarter += 4;
       year -= 1;
     }
+    buckets.set(`${year}-Q${quarter}`, []);
+  }
 
-    const periodLabel = `${year}-Q${quarter}`;
+  for (const row of rows) {
+    const d = row.submittedAt;
+    const q = Math.floor(d.getMonth() / 3) + 1;
+    const label = `${d.getFullYear()}-Q${q}`;
+    const bucket = buckets.get(label);
+    if (bucket) bucket.push(row.rating);
+  }
 
-    // Calculate date range for this quarter
-    const quarterStart = new Date(year, (quarter - 1) * 3, 1);
-    const quarterEnd = new Date(year, quarter * 3, 0, 23, 59, 59);
-
-    const responses = await prisma.feedbackResponse.findMany({
-      where: {
-        submittedAt: {
-          gte: quarterStart,
-          lte: quarterEnd,
-        },
-      },
-      select: {
-        rating: true,
-      },
-    });
-
-    const ratings = responses.map((r) => r.rating);
+  const results: TrendDataPoint[] = [];
+  for (const [period, ratings] of buckets.entries()) {
     const responseCount = ratings.length;
-
     const averageRating =
       responseCount > 0
         ? Math.round((ratings.reduce((sum, r) => sum + r, 0) / responseCount) * 10) / 10
         : 0;
-
     const nps = calculateNPS(ratings);
-
     results.push({
-      period: periodLabel,
+      period,
       averageRating,
       responseCount,
       npsScore: nps.score,
@@ -254,7 +601,9 @@ export async function getTrendData(quarters: number = 4): Promise<TrendDataPoint
 }
 
 /**
- * Get recent comments (anonymized for accountant view)
+ * Get recent comments (anonymized for accountant view).
+ *
+ * Reads from `feedbackResponse ∪ surveyVote(active)` (see ADR-007).
  *
  * @param limit - Maximum number of comments to return
  * @param includeClientInfo - Whether to include client identifying info (manager only)
@@ -272,35 +621,24 @@ export async function getRecentComments(
     clientUsername?: string | null;
   }>
 > {
-  const responses = await prisma.feedbackResponse.findMany({
-    where: {
-      comment: {
-        not: null,
-      },
-    },
-    select: {
-      comment: true,
-      rating: true,
-      submittedAt: true,
-      chatId: includeClientInfo,
-      clientUsername: includeClientInfo,
-    },
-    orderBy: {
-      submittedAt: 'desc',
-    },
-    take: limit,
-  });
+  const rows = await fetchUnifiedComments({ limit });
 
-  return responses.map((r) => ({
+  return rows.map((r) => ({
     comment: r.comment!,
     rating: r.rating,
     submittedAt: r.submittedAt,
-    ...(includeClientInfo && { chatId: r.chatId?.toString(), clientUsername: r.clientUsername }),
+    ...(includeClientInfo && {
+      chatId: r.chatId?.toString(),
+      clientUsername: r.clientUsername,
+    }),
   }));
 }
 
 /**
- * Get feedback summary for a specific survey
+ * Get feedback summary for a specific survey.
+ *
+ * Aggregates go through the unified helper (legacy + active votes). The
+ * "low rating" count is also unified so the manager UI reflects both sources.
  *
  * @param surveyId - Survey ID to get summary for
  * @returns Survey feedback summary
@@ -335,13 +673,9 @@ export async function getSurveySummary(surveyId: string): Promise<{
 
   const aggregates = await getAggregates(undefined, surveyId);
 
-  // Count low ratings (1-3) for manager attention
-  const lowRatingCount = await prisma.feedbackResponse.count({
-    where: {
-      surveyId,
-      rating: { lte: 3 },
-    },
-  });
+  // Count low ratings (1-3) across both sources.
+  const rows = await fetchUnifiedRatings({ surveyId });
+  const lowRatingCount = rows.filter((r) => r.rating <= 3).length;
 
   logger.info('Survey summary retrieved', {
     surveyId,
@@ -365,4 +699,7 @@ export default {
   getTrendData,
   getRecentComments,
   getSurveySummary,
+  fetchUnifiedRatings,
+  fetchUnifiedEntries,
+  fetchUnifiedComments,
 };

--- a/backend/src/services/feedback/analytics.service.ts
+++ b/backend/src/services/feedback/analytics.service.ts
@@ -216,12 +216,22 @@ export async function fetchUnifiedEntries(
   opts: UnifiedEntryFilters & { page?: number; pageSize?: number }
 ): Promise<{ items: UnifiedEntryRow[]; total: number }> {
   const timeFilter = buildTimeFilter(opts.dateFrom, opts.dateTo);
+  const hasScopedChatIds = Array.isArray(opts.scopedChatIds);
+
+  // Intersection guard: when both scope and explicit chatId are supplied,
+  // the explicit chat must belong to scope, otherwise return an empty result.
+  if (hasScopedChatIds && opts.chatId !== undefined && !opts.scopedChatIds.includes(opts.chatId)) {
+    return { items: [], total: 0 };
+  }
 
   const legacyWhere: Prisma.FeedbackResponseWhereInput = {};
   if (timeFilter) legacyWhere.submittedAt = timeFilter;
   if (opts.surveyId) legacyWhere.surveyId = opts.surveyId;
-  if (opts.scopedChatIds) legacyWhere.chatId = { in: opts.scopedChatIds };
-  if (opts.chatId !== undefined) legacyWhere.chatId = opts.chatId;
+  if (opts.chatId !== undefined) {
+    legacyWhere.chatId = opts.chatId;
+  } else if (hasScopedChatIds) {
+    legacyWhere.chatId = { in: opts.scopedChatIds };
+  }
   if (opts.minRating !== undefined || opts.maxRating !== undefined) {
     const ratingFilter: Prisma.IntFilter = {};
     if (opts.minRating !== undefined) ratingFilter.gte = opts.minRating;
@@ -232,12 +242,15 @@ export async function fetchUnifiedEntries(
   const voteWhere: Prisma.SurveyVoteWhereInput = { state: 'active' };
   if (timeFilter) voteWhere.updatedAt = timeFilter;
   const needsDeliveryJoin =
-    opts.surveyId !== undefined || opts.scopedChatIds !== undefined || opts.chatId !== undefined;
+    opts.surveyId !== undefined || hasScopedChatIds || opts.chatId !== undefined;
   if (needsDeliveryJoin) {
     const deliveryWhere: Prisma.SurveyDeliveryWhereInput = {};
     if (opts.surveyId) deliveryWhere.surveyId = opts.surveyId;
-    if (opts.scopedChatIds) deliveryWhere.chatId = { in: opts.scopedChatIds };
-    if (opts.chatId !== undefined) deliveryWhere.chatId = opts.chatId;
+    if (opts.chatId !== undefined) {
+      deliveryWhere.chatId = opts.chatId;
+    } else if (hasScopedChatIds) {
+      deliveryWhere.chatId = { in: opts.scopedChatIds };
+    }
     voteWhere.delivery = deliveryWhere;
   }
   if (opts.minRating !== undefined || opts.maxRating !== undefined) {

--- a/docs/adr/007-survey-feedback-data-source.md
+++ b/docs/adr/007-survey-feedback-data-source.md
@@ -1,0 +1,154 @@
+# ADR-007: Source of truth для survey feedback (surveyVote vs feedbackResponse)
+
+## Статус
+
+Принято
+
+## Дата
+
+2026-04-20
+
+## Контекст
+
+В проекте существуют **две таблицы** для хранения ответов на опросы:
+
+| Таблица | Появилась | Семантика | Текущее использование |
+|---|---|---|---|
+| `feedback_responses` (`FeedbackResponse`) | Оригинальная модель quarterly-surveys | **Один ответ на delivery**, unique по `delivery_id` | Legacy. Только historical data до gh-294 merge |
+| `survey_votes` + `survey_vote_history` (`SurveyVote`, `SurveyVoteHistory`) | gh-294 / PR #304 (multi-user voting, 2026-04) | **Множество голосов на delivery** по разным `telegram_user_id`, изменяемые, с историей | Canonical. Все новые голоса после merge PR #304 |
+
+### Проблема, описанная в issue #324
+
+Write-path мигрировал: `backend/src/bot/handlers/survey.handler.ts:185-190` вызывает `submitVote(...)` → `surveyVote`. Legacy `recordResponse(...)` (пишущий в `feedbackResponse`) больше не вызывается из бота.
+
+Но read-path `/feedback` остался на legacy:
+- `backend/src/services/feedback/analytics.service.ts:134-300` — читает `feedbackResponse` для `getAggregates`, `getTrendData`, `getRecentComments`
+- `backend/src/api/trpc/routers/feedback.ts:62-576` — `getAll`, `exportCsv`, `getById`, `getAggregates` scoped/unscoped — все бьют `feedbackResponse`
+
+В результате **все новые голоса после gh-294 невидимы на `/feedback`**. Фронт дополнительно маскирует пустое состояние `mockAggregatesData` / `mockFeedbackEntries` (строки 216-240), скрывая bug.
+
+### Декомпозиция различий между моделями
+
+1. **Ключевая структура**
+   - `FeedbackResponse.deliveryId` — `UNIQUE` (один ответ на одно отправление).
+   - `SurveyVote.(deliveryId, telegramUserId)` — `UNIQUE` составной ключ (N ответов от разных юзеров в одной группе).
+2. **Chat reference**
+   - `FeedbackResponse.chatId` — прямое FK.
+   - `SurveyVote` получает `chatId` только через `SurveyDelivery.chatId`.
+3. **Timestamp semantics**
+   - `FeedbackResponse.submittedAt` — момент первичного ответа (immutable).
+   - `SurveyVote.createdAt` — первичный голос; `SurveyVote.updatedAt` — последний re-vote (ре-голосование сдвигает).
+4. **История изменений**
+   - `FeedbackResponse` — нет; ответ immutable.
+   - `SurveyVote` + `SurveyVoteHistory` — каждое изменение (create/update/remove) логируется.
+5. **State machine**
+   - `FeedbackResponse` — всегда активно (удаление = hard delete).
+   - `SurveyVote.state ∈ {active, removed}` — soft delete через `state='removed'`.
+
+### Рассмотренные альтернативы
+
+1. **Pure cutover (читать только `surveyVote`).** Отклонено: теряем всю исторически собранную feedback-аналитику до gh-294 (кварталы 2025-Q1..Q4 и 2026-Q1).
+2. **One-time backfill `feedbackResponse ← surveyVote`.** Отклонено: (а) риск порчи historical данных при ошибке скрипта (irreversible); (б) две source-of-truth для write — путь к drift'у; (в) не поддерживает multi-vote семантику (`FeedbackResponse` unique по delivery).
+3. **UNION ALL в read-only слое (обе таблицы, merge in-memory).** **Принято.** Zero data loss, reversible, не требует DB-миграции, не задевает write-path, поддерживает семантику обеих моделей без потерь.
+
+## Решение
+
+### 1. Canonical write model
+
+- `SurveyVote` + `SurveyVoteHistory` — **единственный** write target для новых голосов.
+- `feedbackResponse` **deprecated for writes**. Код `recordResponse(...)` в `backend/src/services/feedback/survey.service.ts:816-824` и tRPC mutation `feedback.submitRating` (`feedback.ts:170-242`) помечаются `@deprecated`. Не удаляются в этом PR (внешние клиенты могут зависеть), но новые фичи **не должны** их звать. Удаление — отдельным тикетом не раньше чем через 2 квартала.
+
+### 2. Canonical read model
+
+`/feedback` APIs возвращают **UNION** двух источников:
+
+```
+items = (feedbackResponse) ∪ (surveyVote WHERE state='active')
+  ordered by submittedAt DESC
+  filtered by user scoping
+  paginated in-memory
+```
+
+Реализация — `Promise.all([findMany, findMany])` + merge/sort в JS. Prisma не поддерживает UNION нативно; `$queryRaw` отложено до масштаба >10k строк на клиента.
+
+### 3. Aggregation semantics
+
+- **NPS / average / distribution**: считаются на объединённом наборе `rating`-значений.
+- **Multi-vote семантика**: `SurveyVote` хранит последний активный голос каждого `(delivery, user)`. Re-vote **не** даёт второй подсчёт — предыдущий голос state='active' обновляется, не создаётся новый. `SurveyVoteHistory` хранит цепочку для аудита, но **не** участвует в агрегатах.
+- **`state='removed'`**: исключается из всех агрегатов и listings.
+- **Scoping**: `getScopedChatIds(...)` применяется к обеим ветвям UNION:
+  - `feedbackResponse.chatId IN scopedChatIds`
+  - `surveyVote.delivery.chatId IN scopedChatIds`
+
+### 4. DTO mapping
+
+Shape DTO для `feedback.getAll.items[i]` **не меняется** (фронт привязан):
+
+| Поле | Legacy source | Vote source |
+|---|---|---|
+| `id` | `response.id` | `vote.id` |
+| `chatId` | `response.chatId` | `vote.delivery.chatId` |
+| `chatTitle` | `response.chat.title` | `vote.delivery.chat.title` |
+| `clientUsername` | `response.clientUsername` | `vote.username` |
+| `accountantUsername` | `response.chat.assignedAccountant.fullName` | `vote.delivery.chat.assignedAccountant.fullName` |
+| `rating` | `response.rating` | `vote.rating` |
+| `comment` | `response.comment` | `vote.comment` |
+| `submittedAt` | `response.submittedAt` | `vote.updatedAt` (re-vote поднимает запись вверх) |
+| `surveyId` | `response.surveyId` | `vote.delivery.surveyId` |
+| `surveyQuarter` | `response.survey.quarter` | `vote.delivery.survey.quarter` |
+
+ID-префикс (`fr_` / `sv_`) **не добавляется**: UUID-коллизия пренебрежима, префикс ломает backward-compat URL/bookmark.
+
+### 5. Dedup
+
+**Не требуется.** Write-periods не пересекаются:
+- До merge PR #304 (gh-294) бот писал ТОЛЬКО в `feedback_responses`.
+- После merge — ТОЛЬКО в `survey_votes`.
+
+Для страховки — CI-инвариант в тестах:
+```sql
+SELECT fr.delivery_id
+FROM feedback_responses fr
+JOIN survey_votes sv ON sv.delivery_id = fr.delivery_id AND sv.state = 'active';
+-- ожидается 0 строк навсегда
+```
+
+Если инвариант когда-либо нарушится — это индикатор что кто-то вернул write в `feedback_responses`. Нужно срочно править.
+
+## Последствия
+
+### Положительные
+
+- Все новые голоса становятся видны на `/feedback` моментально, без DB-миграции.
+- Write-path имеет **один** канонический источник (`surveyVote`), проще reasoning.
+- Historical данные сохраняются — менеджеры видят полную картину с момента gh-292.
+- Откат тривиален: revert PR возвращает legacy-чтение без потерь.
+
+### Отрицательные
+
+- Два `findMany` вместо одного — +1 DB roundtrip (~20ms при параллельном `Promise.all`).
+- Pagination O(N) памяти после in-memory merge. Ограничено `pageSize max 100` уже в роутере; при росте объёмов >10k строк на клиента — отдельный тикет на `$queryRaw UNION ALL` с DB-offset.
+- Две модели для поддержки: разработчики должны помнить что read = union, write = `surveyVote`.
+
+### Риски и митигация
+
+| Риск | Митигация |
+|---|---|
+| Кто-то в будущем вернёт write в `feedback_responses` → dedup сломается | CI-инвариант (см. п.5). ADR запрещает явно. |
+| UUID-коллизия между таблицами → React key-collision | Юнит-тест на unique IDs. Префикс добавить, если риск материализуется. |
+| `submitRating` удалят без замены → внешние клиенты сломаются | Deprecated, warn-log в консоль. Полное удаление — отдельный тикет с поиском вызовов. |
+| In-memory UNION не тянет при масштабе | `pageSize max 100`. При росте — `$queryRaw UNION ALL`. Отдельный тикет. |
+
+## Будущая работа
+
+1. **Q3+ 2026**: one-shot backfill `feedbackResponse → surveyVote` (legacy-данные конвертируем в surveyVote с синтетическим `telegramUserId`). После backfill read-path упрощается до `surveyVote` only.
+2. Удаление `feedbackResponse` таблицы — после backfill и подтверждения что никто её не читает ≥3 месяца.
+3. Полное удаление `submitRating` tRPC-мутации — после аудита внешних клиентов.
+
+## Связи
+
+- Issue: [#324](https://github.com/maslennikov-ig/BuhBot/issues/324)
+- Related features: [#292](https://github.com/maslennikov-ig/BuhBot/issues/292) (custom date ranges), [#294](https://github.com/maslennikov-ig/BuhBot/issues/294) (multi-user voting), [#313](https://github.com/maslennikov-ig/BuhBot/issues/313) (targeted audience)
+- Previous ADR by chronology: [ADR-006](./006-opentelemetry-prisma-vulnerability-remediation.md)
+- Beads: `buh-s71c`
+- PR: (будет заполнено после создания)

--- a/frontend/src/app/feedback/feedback-content.tsx
+++ b/frontend/src/app/feedback/feedback-content.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { AdminLayout } from '@/components/layout/AdminLayout';
 import { NPSWidget, FeedbackTable } from '@/components/feedback';
-import type { FeedbackEntry, FeedbackFilters } from '@/components/feedback';
+import type { FeedbackFilters } from '@/components/feedback';
 import { trpc } from '@/lib/trpc';
 import { HelpButton } from '@/components/ui/HelpButton';
 import { useRoleGuard } from '@/hooks/useRoleGuard';
@@ -13,92 +13,6 @@ import { useRoleGuard } from '@/hooks/useRoleGuard';
 // ============================================
 
 const POLLING_INTERVAL_MS = 60 * 1000; // 1 minute refresh
-
-// ============================================
-// MOCK DATA (fallback)
-// ============================================
-
-const mockAggregatesData = {
-  npsScore: 45,
-  totalResponses: 156,
-  averageRating: 4.2,
-  ratingDistribution: [
-    { rating: 5, count: 68, percentage: 43.6 },
-    { rating: 4, count: 52, percentage: 33.3 },
-    { rating: 3, count: 20, percentage: 12.8 },
-    { rating: 2, count: 10, percentage: 6.4 },
-    { rating: 1, count: 6, percentage: 3.8 },
-  ],
-  trendData: [
-    { period: '2024-Q2', averageRating: 4.0, responseCount: 35, npsScore: 38 },
-    { period: '2024-Q3', averageRating: 4.1, responseCount: 42, npsScore: 42 },
-    { period: '2024-Q4', averageRating: 4.2, responseCount: 48, npsScore: 45 },
-    { period: '2025-Q1', averageRating: 4.2, responseCount: 31, npsScore: 45 },
-  ],
-};
-
-const mockFeedbackEntries: FeedbackEntry[] = [
-  {
-    id: '1',
-    chatId: '123',
-    chatTitle: 'ООО "Ромашка"',
-    clientUsername: 'Иванов И.И.',
-    accountantUsername: 'Петрова А.С.',
-    rating: 5,
-    comment: 'Отличная работа, очень быстро ответили на все вопросы!',
-    submittedAt: new Date('2025-01-15T10:30:00'),
-    surveyId: 'survey-1',
-    surveyQuarter: '2025-Q1',
-  },
-  {
-    id: '2',
-    chatId: '456',
-    chatTitle: 'ИП Сидоров',
-    clientUsername: 'Сидоров С.С.',
-    accountantUsername: 'Козлова М.В.',
-    rating: 4,
-    comment: 'Хорошо, но хотелось бы быстрее получать ответы.',
-    submittedAt: new Date('2025-01-14T14:45:00'),
-    surveyId: 'survey-1',
-    surveyQuarter: '2025-Q1',
-  },
-  {
-    id: '3',
-    chatId: '789',
-    chatTitle: 'АО "Техно"',
-    clientUsername: 'Новиков Н.Н.',
-    accountantUsername: 'Петрова А.С.',
-    rating: 5,
-    comment: null,
-    submittedAt: new Date('2025-01-13T09:15:00'),
-    surveyId: 'survey-1',
-    surveyQuarter: '2025-Q1',
-  },
-  {
-    id: '4',
-    chatId: '101',
-    chatTitle: 'ООО "Строй"',
-    clientUsername: 'Морозов М.М.',
-    accountantUsername: 'Иванова Е.К.',
-    rating: 2,
-    comment: 'Долго ждал ответа, очень недоволен.',
-    submittedAt: new Date('2025-01-12T16:20:00'),
-    surveyId: 'survey-1',
-    surveyQuarter: '2025-Q1',
-  },
-  {
-    id: '5',
-    chatId: '102',
-    chatTitle: 'ИП Волков',
-    clientUsername: 'Волков В.В.',
-    accountantUsername: 'Козлова М.В.',
-    rating: 4,
-    comment: 'В целом хорошо.',
-    submittedAt: new Date('2025-01-11T11:00:00'),
-    surveyId: 'survey-1',
-    surveyQuarter: '2025-Q1',
-  },
-];
 
 // ============================================
 // LOADING SKELETON COMPONENT
@@ -213,10 +127,11 @@ export function FeedbackContent() {
     }
   }, [aggregatesError, feedbackError]);
 
-  // Transform data or use mocks
+  // gh-324 / ADR-007: no mock fallback — render empty state instead when the
+  // APIs legitimately return nothing. Hiding the "no data" case behind demo
+  // numbers is exactly what masked the original read/write mismatch bug.
   const npsWidgetData = React.useMemo(() => {
-    if (!aggregatesData) return mockAggregatesData;
-
+    if (!aggregatesData) return null;
     return {
       npsScore: aggregatesData.npsScore,
       totalResponses: aggregatesData.totalResponses,
@@ -229,16 +144,10 @@ export function FeedbackContent() {
   const feedbackTableData = React.useMemo(() => {
     if (!feedbackData) {
       return {
-        entries: mockFeedbackEntries,
-        pagination: {
-          page: 1,
-          pageSize: 20,
-          totalItems: mockFeedbackEntries.length,
-          totalPages: 1,
-        },
+        entries: [],
+        pagination: { page: 1, pageSize, totalItems: 0, totalPages: 0 },
       };
     }
-
     return {
       entries: feedbackData.items.map((item) => ({
         ...item,
@@ -246,7 +155,7 @@ export function FeedbackContent() {
       })),
       pagination: feedbackData.pagination,
     };
-  }, [feedbackData]);
+  }, [feedbackData, pageSize]);
 
   // Check if user is manager (has access to feedback list)
   const isManager = !feedbackError || feedbackError.data?.code !== 'FORBIDDEN';
@@ -284,13 +193,21 @@ export function FeedbackContent() {
 
       {/* NPS Widget - Visible to all authenticated users */}
       <div className="mb-8">
-        <NPSWidget
-          npsScore={npsWidgetData.npsScore}
-          totalResponses={npsWidgetData.totalResponses}
-          averageRating={npsWidgetData.averageRating}
-          ratingDistribution={npsWidgetData.ratingDistribution}
-          trendData={npsWidgetData.trendData}
-        />
+        {npsWidgetData ? (
+          <NPSWidget
+            npsScore={npsWidgetData.npsScore}
+            totalResponses={npsWidgetData.totalResponses}
+            averageRating={npsWidgetData.averageRating}
+            ratingDistribution={npsWidgetData.ratingDistribution}
+            trendData={npsWidgetData.trendData}
+          />
+        ) : (
+          <div className="rounded-lg border border-[var(--buh-border)] bg-[var(--buh-surface)] p-8 text-center">
+            <p className="text-[var(--buh-foreground-muted)]">
+              Ещё нет отзывов — аналитика NPS появится после первых ответов клиентов.
+            </p>
+          </div>
+        )}
       </div>
 
       {/* Feedback Table - Manager only */}


### PR DESCRIPTION
## Summary

Fixes #324 — after gh-294 PR #304 moved survey voting to `surveyVote` / `surveyVoteHistory`, the `/feedback` page kept reading legacy `feedback_responses` and missed every new response. Additionally the frontend hid the gap behind mock data.

This PR unifies the read path on `feedback_responses ∪ surveyVote(active)` via `Promise.all` + in-memory merge, keeps the public API signatures intact (zero frontend contract changes), and removes the misleading mock fallback. See [ADR-007](docs/adr/007-survey-feedback-data-source.md).

## What changed

| Layer | Change |
|---|---|
| ADR | New `docs/adr/007-survey-feedback-data-source.md` — canonical write + read, rationale, migration path |
| Backend analytics | `fetchUnifiedRatings` / `fetchUnifiedEntries` / `fetchUnifiedComments` — the merge helpers |
| Backend router | `getAll` / `getAggregates` / `getById` / `exportCsv` migrated to the helpers; `submitRating` marked `@deprecated` + warn-log |
| Frontend | Mock data removed, empty state card for no-data |
| Tests | +43 scenarios across 2 new files |

## Verification

- `npm run type-check` (backend+frontend): clean
- `npx vitest run` (backend): **696 tests passed (+43)**, 35 files
- `npx prisma validate`: ok

## Migration safety

No schema or migration changes. Write-path is untouched. `submitRating` still works for any residual caller; the deprecation log surfaces them. Rollback is a plain revert.

## Related

- Issue: #324
- ADR: 007
- Beads: \`buh-s71c\`
- Prior work: #322 (gh-313 / gh-294 fixes)