### PR TITLE
fix(ci): skip monitoring Docker build when infrastructure files unchanged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,55 @@ jobs:
             NEXT_PUBLIC_BOT_NAME=${{ secrets.NEXT_PUBLIC_BOT_NAME }}
             NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
 
+  # ==========================================================================
+  # Build Monitoring Image — only when monitoring files change
+  # ==========================================================================
+  build-monitoring:
+    name: Build Monitoring Image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    if: needs.detect-release-pr.outputs.should_skip_heavy != 'true'
+
+    steps:
+      - name: Check for monitoring changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            monitoring:
+              - 'infrastructure/monitoring/**'
+
+      - name: Checkout code
+        if: steps.filter.outputs.monitoring == 'true' || github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v6
+
+      - name: Get version from package.json
+        if: steps.filter.outputs.monitoring == 'true' || github.event_name == 'workflow_dispatch'
+        id: version
+        run: echo "version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        if: steps.filter.outputs.monitoring == 'true' || github.event_name == 'workflow_dispatch'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to GitHub Container Registry
+        if: steps.filter.outputs.monitoring == 'true' || github.event_name == 'workflow_dispatch'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set lowercase repo name
+        if: steps.filter.outputs.monitoring == 'true' || github.event_name == 'workflow_dispatch'
+        id: repo
+        run: echo "name=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+
       - name: Build and push monitoring image
+        if: steps.filter.outputs.monitoring == 'true' || github.event_name == 'workflow_dispatch'
         uses: docker/build-push-action@v7
         with:
           context: ./infrastructure/monitoring
@@ -335,7 +383,17 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [detect-release-pr, lint, format, type-check, build-docker, security-scan, test]
+    needs:
+      [
+        detect-release-pr,
+        lint,
+        format,
+        type-check,
+        build-docker,
+        build-monitoring,
+        security-scan,
+        test,
+      ]
     if: always()
 
     steps:
@@ -393,6 +451,16 @@ jobs:
               echo "::error::test was unexpectedly skipped"
               FAILED="${FAILED}test,"
             fi
+          fi
+
+          # build-monitoring is skipped when no monitoring files changed — that's expected
+          BUILD_MONITORING_RESULT="${{ needs.build-monitoring.result }}"
+          if [ "$BUILD_MONITORING_RESULT" == "failure" ]; then
+            echo "::error::build-monitoring job failed"
+            FAILED="${FAILED}build-monitoring,"
+          elif [ "$BUILD_MONITORING_RESULT" == "skipped" ]; then
+            echo "::notice::build-monitoring skipped (no monitoring changes)"
+            SKIPPED="${SKIPPED}build-monitoring,"
           fi
 
           if [ -n "$FAILED" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ GEMINI.md
 # Environment variables
 .env
 .env.local
+.kilo/kilo.json
+.kilo/kilo.jsonc


### PR DESCRIPTION
## Summary

- Splits monitoring Docker build into a separate CI job with a paths filter
- Monitoring image (Prometheus + Grafana + Uptime Kuma) now only builds when `infrastructure/monitoring/` files change
- Reduces CI time from ~15 min to ~2 min for regular code pushes

## Problem

The monitoring Docker image takes 15+ minutes to build (downloads Prometheus, Grafana, builds Uptime Kuma). It was being rebuilt on every code push even though the monitoring stack rarely changes. This caused the CI to timeout and be cancelled, which in turn blocked the release-please workflow.