### PR TITLE
fix(ci): checkout before paths-filter so it has git history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,11 @@ jobs:
     if: needs.detect-release-pr.outputs.should_skip_heavy != 'true'
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
       - name: Check for monitoring changes
         id: filter
         uses: dorny/paths-filter@v3
@@ -252,10 +257,6 @@ jobs:
           filters: |
             monitoring:
               - 'infrastructure/monitoring/**'
-
-      - name: Checkout code
-        if: steps.filter.outputs.monitoring == 'true' || github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v6
 
       - name: Get version from package.json
         if: steps.filter.outputs.monitoring == 'true' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

- Moves `actions/checkout` **before** `dorny/paths-filter` in the build-monitoring job
- `paths-filter` needs git history to compare commits — it was failing because checkout ran after it
- Added `fetch-depth: 2` so paths-filter can diff against the previous commit