### PR TITLE
fix(ci): replace paths-filter with git diff to detect monitoring changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,16 +247,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for monitoring changes
         id: filter
-        uses: dorny/paths-filter@v3
-        with:
-          ref: ${{ github.event_name == 'push' && 'HEAD' || '' }}
-          filters: |
-            monitoring:
-              - 'infrastructure/monitoring/**'
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "monitoring=true" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            CHANGED=$(git diff --name-only HEAD~1 HEAD -- infrastructure/monitoring/ 2>/dev/null || echo "")
+            if [ -n "$CHANGED" ]; then
+              echo "monitoring=true" >> $GITHUB_OUTPUT
+            else
+              echo "monitoring=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            # PR event — compare against base
+            CHANGED=$(git diff --name-only origin/${{ github.base_ref || 'main' }} HEAD -- infrastructure/monitoring/ 2>/dev/null || echo "")
+            if [ -n "$CHANGED" ]; then
+              echo "monitoring=true" >> $GITHUB_OUTPUT
+            else
+              echo "monitoring=false" >> $GITHUB_OUTPUT
+            fi
+          fi
 
       - name: Get version from package.json
         if: steps.filter.outputs.monitoring == 'true' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

- Removes the `dorny/paths-filter@v3` action that kept failing on push events
- Replaces with a simple shell script using `git diff` — zero dependencies
- Works for both push events (compares HEAD~1) and PR events (compares against base branch)

## Why

The paths-filter action failed consistently on push-to-main events even with
`ref: HEAD` and `fetch-depth: 2`. A shell script approach is simpler and
more reliable.