### PR TITLE
fix(classifier): switch to gemma-4 primary and deepseek-v4-flash fallback

### DIFF
--- a/backend/src/config/config.service.ts
+++ b/backend/src/config/config.service.ts
@@ -73,7 +73,7 @@ const DEFAULTS: CachedGlobalSettings = {
   aiConfidenceThreshold: 0.7,
   messagePreviewLength: 500,
   openrouterApiKey: null,
-  openrouterModel: 'xiaomi/mimo-v2-flash',
+  openrouterModel: 'google/gemma-4-26b-a4b-it',
   dataRetentionYears: 3,
   surveyValidityDays: 7,
   surveyReminderDay: 2,

--- a/backend/src/services/classifier/types.ts
+++ b/backend/src/services/classifier/types.ts
@@ -67,7 +67,7 @@ export interface ClassifierConfig {
   timeoutMs: number;
   /** Maximum retry attempts for API calls (default: 3) */
   maxRetries: number;
-  /** Fallback OpenRouter model when primary fails (default: google/gemini-2.0-flash-001) */
+  /** Fallback OpenRouter model when primary fails (default: deepseek/deepseek-v4-flash) */
   fallbackModel: string;
   /** Circuit breaker configuration */
   circuitBreaker?: CircuitBreakerConfig;
@@ -80,8 +80,8 @@ export const DEFAULT_CLASSIFIER_CONFIG: ClassifierConfig = {
   aiConfidenceThreshold: 0.7,
   keywordConfidenceThreshold: 0.5,
   cacheTTLHours: 24,
-  openRouterModel: 'xiaomi/mimo-v2-flash',
-  fallbackModel: 'google/gemini-2.0-flash-001',
+  openRouterModel: 'google/gemma-4-26b-a4b-it',
+  fallbackModel: 'deepseek/deepseek-v4-flash',
   timeoutMs: 30000,
   maxRetries: 3,
 };


### PR DESCRIPTION
## Что и зачем

AI-классификатор сообщений упал в keyword-fallback и начал слать клиентам «Проблемы с сетью. Попробуйте позже». Причина двойная:
- основная модель \`xiaomi/mimo-v2-flash\` поймала временный сбой провайдера (\`451 Provider returned error\`);
- fallback \`google/gemini-2.0-flash-001\` **снят с OpenRouter** (\`404 No endpoints found\`) — подстраховки не было.

## Изменения

- **Fallback модель** → \`deepseek/deepseek-v4-flash\` (вместо мёртвой gemini-2.0-flash-001)
- **Дефолт primary** → \`google/gemma-4-26b-a4b-it\` для консистентности с \`global_settings\` (на проде основная модель уже переключена через БД)
- Дефолты синхронизированы в \`backend/src/services/classifier/types.ts\` и \`backend/src/config/config.service.ts\`
- \`chore(deps)\`: зафиксирован \`packageManager: pnpm@10.33.4\` (под CI \`PNPM_VERSION: 10\`) — устраняет дрейф версий pnpm; lockfile не менялся

## Проверка

- Обе новые модели проверены живым запросом к OpenRouter из прод-региона (EU): \`200 OK\`
- eslint + prettier (pre-commit) пройдены локально
- Полный type-check / build — на CI

Ref buh-k87u

🤖 Generated with [Claude Code](https://claude.com/claude-code)